### PR TITLE
[MS-67] 인증메일 요청, 인증 API HTTP method를 POST로 변경 및 Swagger 표현법 개선

### DIFF
--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/MailErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/MailErrorCode.java
@@ -11,7 +11,7 @@ public enum MailErrorCode implements ErrorCode {
     SES_SERVER_ERROR("MAIL_001", "", HttpStatus.BAD_REQUEST),
     MESSAGING_ERROR("MAIL_002", "메세지 발송에 실패했습니다.", HttpStatus.BAD_REQUEST),
     INVALID_EMAIL_FORM("MAIL_003", "유효하지 않은 이메일 형식입니다.", HttpStatus.BAD_REQUEST),
-    UNSUPPOERTED_DOMAIN("MAIL_004", "지원하지 않는 도메인입니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_DOMAIN("MAIL_004", "지원하지 않는 도메인입니다.", HttpStatus.BAD_REQUEST),
     USED_EMAIL("MAIL_005", "이미 사용중인 이메일입니다.", HttpStatus.BAD_REQUEST),
     CERTIFICATION_CODE_EXPIRED("MAIL_006", "인증 코드가 만료되었거나 존재하지 않습니다.", HttpStatus.BAD_REQUEST),
     CERTIFICATION_CODE_NOT_MATCH("MAIL_007", "인증 코드가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -1,13 +1,17 @@
 package com.modutaxi.api.domain.member.controller;
 
 import com.modutaxi.api.common.auth.CurrentMember;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto;
+import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
+import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmMailCertificationReqeust;
+import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendMailCertificationRequest;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.MailResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.service.UpdateMemberService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,45 +45,108 @@ public class UpdateMemberController {
 
     /**
      * [GET] 이메일 인증 메일 발송
-     * /mail-cert
+     * /api/members/mail/certificate
      */
     @Operation(
-        summary = "이메일 인증 메일 발송",
-        description = "이메일 인증 메일을 발송합니다.<br>" +
-            "인증메일을 요청한 메일 주소로 인증 메일을 발송합니다."
+            summary = "이메일 인증 메일 발송",
+            description = "이메일 인증 메일을 발송합니다.<br>" +
+                    "인증메일을 요청한 메일 주소로 인증 메일을 발송합니다."
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "메일 발송 성공"),
-        @ApiResponse(responseCode = "400", description = "메일 발송 실패"),
-        @ApiResponse(responseCode = "429", description = "단기간 중복 메일 발송 요청"),
+            @ApiResponse(responseCode = "200", description = "메일 발송 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailResponse.class))),
+            @ApiResponse(responseCode = "400", description = "메일 발송 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailErrorCode.class), examples = {
+                    @ExampleObject(name = "MAIL_001", description = "메일 발송 단계에서 실패했습니다.", value = """
+                            {
+                                "errorCode": "MAIL_001",
+                                "message": "메일 발송에 실패했습니다. 서버 관리자에게 문의해주세요."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_003", description = "이메일 형식 문제", value = """
+                            {
+                                "errorCode": "MAIL_003",
+                                "message": "유효하지 않은 이메일 형식입니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_004", description = "지원하지 않는 도메인", value = """
+                            {
+                                "errorCode": "MAIL_004",
+                                "message": "지원하지 않는 도메인입니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_005", description = "사용중인 이메일 주소", value = """
+                            {
+                                "errorCode": "MAIL_005",
+                                "message": "이미 사용중인 이메일입니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_009", description = "인증된 메일 주소가 존재하는 계정", value = """
+                            {
+                                "errorCode": "MAIL_009",
+                                "message": "이미 인증된 계정입니다."
+                            }
+                            """),
+            })),
+            @ApiResponse(responseCode = "429", description = "단기간 중복 메일 발송 요청", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailErrorCode.class), examples = {
+                    @ExampleObject(name = "MAIL_008", description = "단기간에 여러번의 인증메일을 요청할 수 없습니다.", value = """
+                            {
+                                "errorCode": "MAIL_008",
+                                "message": "이미 발송된 인증메일 요청입니다."
+                            }
+                            """),
+            })),
     })
-    @GetMapping("/mail/certificate")
+    @PostMapping("/mail/certificate")
     public ResponseEntity<MailResponse> sendEmailCertificationMail(
-        @CurrentMember Member member,
-        @Parameter(description = "인증 메일을 받을 이메일 주소")
-        @RequestParam String receiver
+            @CurrentMember Member member,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = SendMailCertificationRequest.class)))
+            @RequestBody SendMailCertificationRequest request
     ) {
-        return ResponseEntity.ok(updateMemberService.sendEmailCertificationMail(member.getId(), receiver));
+        return ResponseEntity.ok(updateMemberService.sendEmailCertificationMail(member.getId(), request.getMailAddress()));
     }
 
     /**
      * [GET] 이메일 인증 확인
-     * /mail/confirm
+     * /api/members/mail/confirm
      */
     @Operation(
-        summary = "이메일 인증 확인",
-        description = "수신한 인증 메일을 인증합니다.<br>" +
-            "인증코드를 인증합니다."
+            summary = "이메일 인증 확인",
+            description = "수신한 인증 메일을 인증합니다.<br>" +
+                    "인증코드를 인증합니다."
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "메일 인증 성공"),
-        @ApiResponse(responseCode = "400", description = "메일 인증 실패")
+            @ApiResponse(responseCode = "200", description = "메일 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailResponse.class))),
+            @ApiResponse(responseCode = "400", description = "메일 인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailErrorCode.class), examples = {
+                    @ExampleObject(name = "MAIL_001", description = "메일 발송 단계에서 실패했습니다.", value = """
+                            {
+                                "errorCode": "MAIL_001",
+                                "message": "인증 코드가 만료되었거나 존재하지 않습니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_005", description = "사용중인 이메일 주소", value = """
+                            {
+                                "errorCode": "MAIL_005",
+                                "message": "이미 사용중인 이메일입니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_007", description = "발송된 인증 코드와 일치 하지 않음", value = """
+                            {
+                                "errorCode": "MAIL_007",
+                                "message": "인증 코드가 일치하지 않습니다."
+                            }
+                            """),
+                    @ExampleObject(name = "MAIL_009", description = "인증된 메일 주소가 존재하는 계정", value = """
+                            {
+                                "errorCode": "MAIL_009",
+                                "message": "이미 인증된 계정입니다."
+                            }
+                            """),
+            })),
     })
-    @GetMapping("/mail/confirm")
+    @PostMapping("/mail/confirm")
     public ResponseEntity<MailResponse> confirmEmailCertification(
-        @CurrentMember Member member,
-        @Parameter(description = "인증 메일로 받은 인증 코드")
-        @RequestParam String code) {
-        return ResponseEntity.ok(updateMemberService.checkEmailCertificationCode(member.getId(), code));
+            @CurrentMember Member member,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = ConfirmMailCertificationReqeust.class)))
+            @RequestBody ConfirmMailCertificationReqeust request) {
+        return ResponseEntity.ok(updateMemberService.checkEmailCertificationCode(member.getId(), request.getCertCode()));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.domain.member.dto;
 
 import com.modutaxi.api.domain.member.entity.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,5 +23,19 @@ public class MemberRequestDto {
     @NoArgsConstructor
     public static class LoginRequest {
         private String accessToken;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SendMailCertificationRequest {
+        @Schema(example = "12181659@inha.edu", description = "인증 메일을 받을 이메일 주소")
+        private String mailAddress;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ConfirmMailCertificationReqeust {
+        @Schema(example = "12345", description = "인증 메일로 받은 인증 코드")
+        private String certCode;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.modutaxi.api.domain.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ public class MemberResponseDto {
     @Getter
     @AllArgsConstructor
     public static class MailResponse {
+        @Schema(example = "true", description = "메일 API 성공 여부")
         private Boolean isConfirm;
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -5,7 +5,6 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.domain.mail.service.MailService;
 import com.modutaxi.api.domain.mail.service.MailUtil;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.MailResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
@@ -37,7 +36,7 @@ public class UpdateMemberService {
         }
         // 지원 이메일 도메인 체크
         if (!mailService.checkMailDomain(receiver)) {
-            throw new BaseException(MailErrorCode.UNSUPPOERTED_DOMAIN);
+            throw new BaseException(MailErrorCode.UNSUPPORTED_DOMAIN);
         }
         // 이메일 중복 체크
         getNotCertificatedMember(memberId, receiver);


### PR DESCRIPTION
## 요약 🎀
- 인증메일 요청, 인증 API HTTP method를 POST로 변경
- Swagger 표현법 개선

## 상세 내용 🌈
- 인증메일 요청, 인증 API의 HTTP method를 프론트 측의 요청에 따라 POST로 변경하였으며, Body에 데이터를 담아 통신하도록 하였습니다.
- Swagger 표현법 개선
  - Swagger의 `RequestBody`의 예시를 추가하였습니다.
    <img width="752" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/f878b02c-3d31-4152-b014-e74ce2aea557">
    <img width="747" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/c26cda21-b576-4555-b487-912bf5bd2004">

  - Swagger의 `ResponseBody`의 예시를 추가하였습니다.
    <img width="749" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/e15e59ea-3374-4739-8dd4-5661b4c421bc">
    <img width="743" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/de8a8691-438c-437d-ae05-68c2e8de920d">

  - 에러 상황의 예시 출력을 추가하였습니다.
    <img width="744" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/35f5957d-8a19-4f6b-bcc2-87d9d42e9517">
    <img width="746" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/70e424ef-237e-437b-9f34-81e5a58bcfc5">


## 질문 및 이외 사항 🚩
- Swagger를 이용한 `Reqeust`, `Response`, `Error` 예시 데이터 작성법을 참고해주세요!!