### PR TITLE
프론트 테스트를 위한 JWT 유효시간 임시 변경

### DIFF
--- a/src/main/java/com/modutaxi/api/common/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/modutaxi/api/common/auth/jwt/JwtTokenProvider.java
@@ -34,6 +34,8 @@ public class JwtTokenProvider {
     private static final String REFRESH_HEADER = "refreshToken";  // 리프레시 토큰 헤더 key name
     private static final long TOKEN_VALID_TIME = 1000 * 60L * 60L;  // 유효기간 1시간
     private static final long REF_TOKEN_VALID_TIME = 1000 * 60L * 60L * 24L * 7L;  // 유효기간 일주일
+    private static final long TEMP_TOKEN_VALID_TIME = 1000 * 30L;  // 임시 유효기간! -> 30초
+    private static final long TEMP_REF_TOKEN_VALID_TIME = 1000 * 60L;  // 임시 유효기간! -> 1분
 
     private final RedisRTKRepositoryImpl redisRTKRepository;
 
@@ -51,7 +53,7 @@ public class JwtTokenProvider {
      */
     public String generateAccessToken(Claims claims) {
         Date now = new Date();
-        Date accessTokenExpirationTime = new Date(now.getTime() + TOKEN_VALID_TIME);
+        Date accessTokenExpirationTime = new Date(now.getTime() + TEMP_TOKEN_VALID_TIME);
 
         return Jwts.builder()
             .setClaims(claims)  // 정보 저장
@@ -66,7 +68,7 @@ public class JwtTokenProvider {
      */
     public String generateRefreshToken(Claims claims) {
         Date now = new Date();
-        Date refreshTokenExpirationTime = new Date(now.getTime() + REF_TOKEN_VALID_TIME);
+        Date refreshTokenExpirationTime = new Date(now.getTime() + TEMP_REF_TOKEN_VALID_TIME);
 
         return Jwts.builder()
             .setClaims(claims)  // 정보 저장


### PR DESCRIPTION
## 요약 🎀

- 프론트 분이 요청하셔서 JWT 유효시간을 임시로 변경했습니다.

## 상세 내용 🌈

- ATK은 30s이고 RTK은 60s입니다.

## 질문 및 이외 사항 🚩

- 테스트 후 바로 복귀 시켜놓겠습니다.

## 리뷰어에게 ✨

-
