### PR TITLE
[MS-81] 모집방 목록 조회 필터 추가

### DIFF
--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
@@ -11,6 +11,7 @@ public enum RoomErrorCode implements ErrorCode {
     EMPTY_ROOM("ROOM_001", "존재하지 않는 방입니다.", HttpStatus.CONFLICT),
     NOT_ROOM_MANAGER("ROOM_002", "권한이 없는 사용자입니다.", HttpStatus.CONFLICT),
     ALREADY_MEMBER_IS_MANAGER("ROOM_003", "방을 두 개 이상 만들 수 없습니다.", HttpStatus.CONFLICT),
+    BOTH_GENDER("ROOM_004", "성별 제한이 둘 다 설정되어 있습니다.", HttpStatus.CONFLICT),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
@@ -1,19 +1,23 @@
 package com.modutaxi.api.domain.room.controller;
 
+import com.modutaxi.api.common.exception.errorcode.SpotError;
 import com.modutaxi.api.common.pagination.PageResponseDto;
+import com.modutaxi.api.domain.room.dto.RoomRequestDto.GetSimpleListRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomSimpleResponse;
 import com.modutaxi.api.domain.room.service.GetRoomService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,10 +37,31 @@ public class GetRoomController {
     }
 
     @Operation(summary = "경로를 제외한 방 리스트 조회",
-        description = "\n\n\n**page(0 ~ )** : 페이지 번호\n\n**size(1 ~ )** : 사이즈")
-    @GetMapping
+            description = "방 리스트를 조회합니다.<br><br>**spotId**(찾으려는 거점 id, 필수 x), **isImminent**(마감 임박 여부), **roomTags**(찾으려는 방 태그, 필수 x)를 함께 보내주세요.<br><br> **roomTag** : 'ONLY_WOMAN', 'ONLY_MAN', 'MANNER', 'QUIET', 'STUDENT_CERTIFICATION'<br><br>**page(0 ~ )** : 페이지 번호<br><br>**size(1 ~ )** : 사이즈")
+    @PostMapping("/list")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "방 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoomSimpleResponse.class))),
+            @ApiResponse(responseCode = "400", description = "방 목록 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SpotError.class), examples = {
+                    @ExampleObject(name = "SPOT_001", value = """
+                            {
+                                "code": "SPOT_001",
+                                "message": "존재하지 않는 거점 ID 입니다.",
+                                "timeStamp": "2024-04-04T02:48:31.646102"
+                            }
+                            """, description = "일치하는 ID를 가진 거점이 존재하지 않습니다.")
+            })),
+            @ApiResponse(responseCode = "409", description = "방 목록 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SpotError.class), examples = {
+                    @ExampleObject(name = "ROOM_004", value = """
+                            {
+                                "code": "ROOM_004",
+                                "message": "성별 제한이 둘 다 설정되어 있습니다.",
+                                "timeStamp": "2024-04-04T02:48:31.646102"
+                            }
+                            """, description = "성별 제한이 둘 다 설정되어 있습니다.")
+            })),
+    })
     public ResponseEntity<PageResponseDto<List<RoomSimpleResponse>>> getRoomSimpleList(
-        @RequestParam int page, @RequestParam int size) {
-        return ResponseEntity.ok(getRoomService.getRoomSimpleList(page, size));
+            @RequestParam int page, @RequestParam int size, @RequestBody(required = false) GetSimpleListRequest body) {
+        return ResponseEntity.ok(getRoomService.getRoomSimpleList(page, size, body.getSpotId(), body.getRoomTags(), body.getIsImminent()));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
@@ -2,9 +2,9 @@ package com.modutaxi.api.domain.room.controller;
 
 import com.modutaxi.api.common.exception.errorcode.SpotError;
 import com.modutaxi.api.common.pagination.PageResponseDto;
-import com.modutaxi.api.domain.room.dto.RoomRequestDto.GetSimpleListRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomSimpleResponse;
+import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import com.modutaxi.api.domain.room.service.GetRoomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -38,7 +38,7 @@ public class GetRoomController {
 
     @Operation(summary = "경로를 제외한 방 리스트 조회",
             description = "방 리스트를 조회합니다.<br><br>**spotId**(찾으려는 거점 id, 필수 x), **isImminent**(마감 임박 여부), **roomTags**(찾으려는 방 태그, 필수 x)를 함께 보내주세요.<br><br> **roomTag** : 'ONLY_WOMAN', 'ONLY_MAN', 'MANNER', 'QUIET', 'STUDENT_CERTIFICATION'<br><br>**page(0 ~ )** : 페이지 번호<br><br>**size(1 ~ )** : 사이즈")
-    @PostMapping("/list")
+    @GetMapping("/list")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "방 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoomSimpleResponse.class))),
             @ApiResponse(responseCode = "400", description = "방 목록 조회 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SpotError.class), examples = {
@@ -61,7 +61,7 @@ public class GetRoomController {
             })),
     })
     public ResponseEntity<PageResponseDto<List<RoomSimpleResponse>>> getRoomSimpleList(
-            @RequestParam int page, @RequestParam int size, @RequestBody(required = false) GetSimpleListRequest body) {
-        return ResponseEntity.ok(getRoomService.getRoomSimpleList(page, size, body.getSpotId(), body.getRoomTags(), body.getIsImminent()));
+            @RequestParam int page, @RequestParam int size, @RequestParam(required = false) Long spotId, @RequestParam(required = false) List<RoomTagBitMask> roomTags, @RequestParam(required = false) Boolean isImminent) {
+        return ResponseEntity.ok(getRoomService.getRoomSimpleList(page, size, spotId, roomTags, isImminent));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -3,9 +3,12 @@ package com.modutaxi.api.domain.room.dto;
 import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.geo.Point;
 
 public class RoomRequestDto {
@@ -43,5 +46,17 @@ public class RoomRequestDto {
         private LocalDateTime departureTime;
 
         private int wishHeadcount;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GetSimpleListRequest {
+        @Schema(example = "1", description = "찾으려는 거점 id")
+        private Long spotId;
+        @Schema(example = "false", description = "마감 임박")
+        private Boolean isImminent;
+        @Schema(example = "[\"REGARDLESS_OF_GENDER\", \"STUDENT_CERTIFICATION\"]", description = "모집방 태그")
+        private List<RoomTagBitMask> roomTags;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -56,7 +56,7 @@ public class RoomRequestDto {
         private Long spotId;
         @Schema(example = "false", description = "마감 임박")
         private Boolean isImminent;
-        @Schema(example = "[\"REGARDLESS_OF_GENDER\", \"STUDENT_CERTIFICATION\"]", description = "모집방 태그")
+        @Schema(example = "[\"ONLY_MAN\", \"STUDENT_CERTIFICATION\"]", description = "모집방 태그")
         private List<RoomTagBitMask> roomTags;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -47,16 +47,4 @@ public class RoomRequestDto {
 
         private int wishHeadcount;
     }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class GetSimpleListRequest {
-        @Schema(example = "1", description = "찾으려는 거점 id")
-        private Long spotId;
-        @Schema(example = "false", description = "마감 임박")
-        private Boolean isImminent;
-        @Schema(example = "[\"ONLY_MAN\", \"STUDENT_CERTIFICATION\"]", description = "모집방 태그")
-        private List<RoomTagBitMask> roomTags;
-    }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/entity/RoomStatus.java
+++ b/src/main/java/com/modutaxi/api/domain/room/entity/RoomStatus.java
@@ -3,7 +3,7 @@ package com.modutaxi.api.domain.room.entity;
 public enum RoomStatus {
     PROCEEDING("모집 중"),
     COMPLETE("완료"),
-    IMMINENT("마감 임박");
+    ;
 
     private final String status;
 

--- a/src/main/java/com/modutaxi/api/domain/room/entity/RoomTagBitMask.java
+++ b/src/main/java/com/modutaxi/api/domain/room/entity/RoomTagBitMask.java
@@ -1,17 +1,18 @@
 package com.modutaxi.api.domain.room.entity;
 
 public enum RoomTagBitMask {
-    ONLY_WOMAN(1),
-    ONLY_MAN(2),
-    REGARDLESS_OF_GENDER(4),
-
-    STUDENT_CERTIFICATION(8);
+    ONLY_WOMAN,
+    ONLY_MAN,
+    MANNER,
+    QUIET,
+    STUDENT_CERTIFICATION
+    ;
 
 
     private int value;
 
-    RoomTagBitMask(int value) {
-        this.value = value;
+    RoomTagBitMask() {
+        this.value = 1 << this.ordinal();
     }
 
     public int getValue() {

--- a/src/main/java/com/modutaxi/api/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/room/repository/RoomRepository.java
@@ -11,13 +11,7 @@ import java.time.LocalDateTime;
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     boolean existsRoomByRoomManagerId(Long memberId);
-    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 ORDER BY r.createdAt DESC")
-    Slice<Room> findAllWhereTagBitMaskOrderByCreatedAtDesc(Integer tagBitMask, Pageable pageable);
-    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.spot.id = :spotId ORDER BY r.createdAt DESC")
-    Slice<Room> findAllWhereTagBitMaskAndSpotIdOrderByCreatedAtDesc(Long spotId, Integer tagBitMask, Pageable pageable);
-    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.departureTime BETWEEN :timeAfter AND :timeBefore ORDER BY r.createdAt DESC")
-    Slice<Room> findAllWhereBetweenTimeAndTagBitMaskOrderByCreatedAtDesc(Integer tagBitMask, LocalDateTime timeAfter, LocalDateTime timeBefore, Pageable pageable);
-    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.departureTime BETWEEN :timeAfter AND :timeBefore AND r.spot.id = :spotId ORDER BY r.createdAt DESC")
-    Slice<Room> findAllWhereBetweenTimeAndTagBitMaskAndSpotIdOrderByCreatedAtDesc(Long spotId, Integer tagBitMask, LocalDateTime timeAfter, LocalDateTime timeBefore, Pageable pageable);
+    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND ( :isImminent = false OR r.departureTime BETWEEN :timeAfter AND :timeBefore ) AND ( :spotId IS NULL OR :spotId = r.spot.id ) ORDER BY r.createdAt DESC")
+    Slice<Room> findAllWhereTagBitMaskOrderByCreatedAtDesc(Long spotId, Integer tagBitMask, Boolean isImminent, LocalDateTime timeAfter, LocalDateTime timeBefore, Pageable pageable);
 
 }

--- a/src/main/java/com/modutaxi/api/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/room/repository/RoomRepository.java
@@ -4,10 +4,20 @@ import com.modutaxi.api.domain.room.entity.Room;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     boolean existsRoomByRoomManagerId(Long memberId);
+    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 ORDER BY r.createdAt DESC")
+    Slice<Room> findAllWhereTagBitMaskOrderByCreatedAtDesc(Integer tagBitMask, Pageable pageable);
+    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.spot.id = :spotId ORDER BY r.createdAt DESC")
+    Slice<Room> findAllWhereTagBitMaskAndSpotIdOrderByCreatedAtDesc(Long spotId, Integer tagBitMask, Pageable pageable);
+    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.departureTime BETWEEN :timeAfter AND :timeBefore ORDER BY r.createdAt DESC")
+    Slice<Room> findAllWhereBetweenTimeAndTagBitMaskOrderByCreatedAtDesc(Integer tagBitMask, LocalDateTime timeAfter, LocalDateTime timeBefore, Pageable pageable);
+    @Query("SELECT r FROM Room r WHERE BITAND(r.roomTagBitMask, :tagBitMask) = :tagBitMask AND r.roomStatus = 0 AND r.departureTime BETWEEN :timeAfter AND :timeBefore AND r.spot.id = :spotId ORDER BY r.createdAt DESC")
+    Slice<Room> findAllWhereBetweenTimeAndTagBitMaskAndSpotIdOrderByCreatedAtDesc(Long spotId, Integer tagBitMask, LocalDateTime timeAfter, LocalDateTime timeBefore, Pageable pageable);
 
-    Slice<Room> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
@@ -68,17 +68,7 @@ public class GetRoomService {
     private Slice<Room> getRoomSlice(Pageable pageable, Long spotId, Integer tagBitMask, Boolean isImminent) {
         if (spotId != null)
             getSpotService.getSpot(spotId);
-        if (isImminent) {
-            LocalDateTime timeNow = LocalDateTime.now();
-            if (spotId == null)
-                return roomRepository.findAllWhereBetweenTimeAndTagBitMaskOrderByCreatedAtDesc(tagBitMask, timeNow.minusMinutes(imminentTimeFront), timeNow.plusMinutes(imminentTimeBack), pageable);
-            else
-                return roomRepository.findAllWhereBetweenTimeAndTagBitMaskAndSpotIdOrderByCreatedAtDesc(spotId, tagBitMask, timeNow.minusMinutes(imminentTimeFront), timeNow.plusMinutes(imminentTimeBack), pageable);
-        } else {
-            if (spotId == null)
-                return roomRepository.findAllWhereTagBitMaskOrderByCreatedAtDesc(tagBitMask, pageable);
-            else
-                return roomRepository.findAllWhereTagBitMaskAndSpotIdOrderByCreatedAtDesc(spotId, tagBitMask, pageable);
-        }
+        LocalDateTime timeNow = LocalDateTime.now();
+        return roomRepository.findAllWhereTagBitMaskOrderByCreatedAtDesc(spotId, tagBitMask, isImminent, timeNow.minusMinutes(imminentTimeFront), timeNow.plusMinutes(imminentTimeBack), pageable);
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
@@ -1,5 +1,6 @@
 package com.modutaxi.api.domain.room.service;
 
+import com.modutaxi.api.common.converter.RoomTagBitMaskConverter;
 import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
 import com.modutaxi.api.common.exception.errorcode.TaxiInfoErrorCode;
@@ -7,23 +8,33 @@ import com.modutaxi.api.common.pagination.PageResponseDto;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomSimpleResponse;
 import com.modutaxi.api.domain.room.entity.Room;
+import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
+import com.modutaxi.api.domain.spot.service.GetSpotService;
 import com.modutaxi.api.domain.taxiinfo.repository.TaxiInfoMongoRepository;
 import com.mongodb.client.model.geojson.LineString;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Service
 public class GetRoomService {
+    @Value("${env.imminent-time.front}")
+    private Long imminentTimeFront;
+    @Value("${env.imminent-time.back}")
+    private Long imminentTimeBack;
 
     private final RoomRepository roomRepository;
     private final TaxiInfoMongoRepository taxiInfoMongoRepository;
+    private final GetSpotService getSpotService;
 
     public RoomDetailResponse getRoomDetail(Long roomId) {
         Room room = roomRepository.findById(roomId)
@@ -36,15 +47,38 @@ public class GetRoomService {
         return RoomDetailResponse.toDto(room, path);
     }
 
-    public PageResponseDto<List<RoomSimpleResponse>> getRoomSimpleList(int page, int size) {
+    public PageResponseDto<List<RoomSimpleResponse>> getRoomSimpleList(int page, int size, Long spotId, List<RoomTagBitMask> tags, Boolean isImminent) {
         Pageable pageable = PageRequest.of(page, size);
-        Slice<Room> roomSlice = roomRepository.findAllByOrderByCreatedAtDesc(pageable);
-
+        Slice<Room> roomSlice = getRoomSlice(pageable, spotId, checkTags(tags), isImminent);
         List<RoomSimpleResponse> roomSimpleResponseList = roomSlice.stream()
             .map(RoomSimpleResponse::toDto)
             .collect(Collectors.toList());
 
         return new PageResponseDto<>(pageable.getPageNumber(), roomSlice.hasNext(),
             roomSimpleResponseList);
+    }
+
+    private Integer checkTags(List<RoomTagBitMask> tags) {
+        Integer tagBitMask = RoomTagBitMaskConverter.convertRoomTagListToBitMask(tags);
+        if ((RoomTagBitMask.ONLY_WOMAN.getValue() + RoomTagBitMask.ONLY_MAN.getValue() & tagBitMask) == RoomTagBitMask.ONLY_WOMAN.getValue() + RoomTagBitMask.ONLY_MAN.getValue())
+            throw new BaseException(RoomErrorCode.BOTH_GENDER);
+        return tagBitMask;
+    }
+
+    private Slice<Room> getRoomSlice(Pageable pageable, Long spotId, Integer tagBitMask, Boolean isImminent) {
+        if (spotId != null)
+            getSpotService.getSpot(spotId);
+        if (isImminent) {
+            LocalDateTime timeNow = LocalDateTime.now();
+            if (spotId == null)
+                return roomRepository.findAllWhereBetweenTimeAndTagBitMaskOrderByCreatedAtDesc(tagBitMask, timeNow.minusMinutes(imminentTimeFront), timeNow.plusMinutes(imminentTimeBack), pageable);
+            else
+                return roomRepository.findAllWhereBetweenTimeAndTagBitMaskAndSpotIdOrderByCreatedAtDesc(spotId, tagBitMask, timeNow.minusMinutes(imminentTimeFront), timeNow.plusMinutes(imminentTimeBack), pageable);
+        } else {
+            if (spotId == null)
+                return roomRepository.findAllWhereTagBitMaskOrderByCreatedAtDesc(tagBitMask, pageable);
+            else
+                return roomRepository.findAllWhereTagBitMaskAndSpotIdOrderByCreatedAtDesc(spotId, tagBitMask, pageable);
+        }
     }
 }


### PR DESCRIPTION
## 요약 🎀
- 모집방 목록 조회 필터 추가

## 상세 내용 🌈
- 모집방 목록 조회 필터 추가
  - 마감임박 필터
    - PM 님과 얘기하여 시간 기준으로 현재시간보다 -10분 ~ 20분 범위의 모집방을 조회하도록 하였습니다.
  - 카테고리 필터
    - 남자만/여자만, 매너탑승, 조용히, 학생인증
  - 도착 거점 필터
    - 거점 id를 입력하요 필터링

## 질문 및 이외 사항 🚩
- 방 목록 조회와 맞지 않는 엔드포인트라 생각되어 `POST` `/api/rooms/list` 로 엔드포인트를 재구성하였습니다.
  <img width="1229" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/e8da9ce3-73a1-40d7-8575-1e90ffcc14a3">