### PR TITLE
[MS-91] 전화번호 메시지 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     // Spatial Data
     implementation 'org.hibernate.orm:hibernate-spatial:6.4.4.Final'
+
+    //Cool SMS
+    implementation 'net.nurigo:sdk:4.2.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/SmsErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/SmsErrorCode.java
@@ -1,0 +1,23 @@
+package com.modutaxi.api.common.exception.errorcode;
+
+import com.modutaxi.api.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SmsErrorCode implements ErrorCode {
+    CERTIFICATION_CODE_EXPIRED("SMS_001", "인증번호가 만료되었거나 없습니다.", HttpStatus.BAD_REQUEST),
+    PHONE_NUMBER_NOT_MATCH("SMS_002", "인증번호를 요청한 번호와 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CERTIFICATION_CODE_NOT_MATCH("SMS_003", "인증번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    CERTIFICATION_CODE_ALREADY_SENT("SMS_004", "이미 인증번호가 발송되었습니다. 잠시후 재시도 해주세요.", HttpStatus.BAD_REQUEST),
+    CERTIFICATION_CODE_SENDING("SMS_005", "인증번호가 발송중입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PHONE_NUMBER_PATTERN("SMS_006", "유효하지 않은 전화번호 형식입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CERTIFICATION_CODE_PATTERN("SMS_007", "유효하지 않은 인증코드 형식입니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/modutaxi/api/common/util/cert/CertificationCodeUtil.java
+++ b/src/main/java/com/modutaxi/api/common/util/cert/CertificationCodeUtil.java
@@ -1,0 +1,12 @@
+package com.modutaxi.api.common.util.cert;
+
+public class CertificationCodeUtil {
+    public static String generateCertificationCode(int length) {
+        final String candidateChars = "1234567890";
+        String code = "";
+        for (int i = 0; i < length; i++) {
+            code += candidateChars.charAt((int) (Math.random() * candidateChars.length()));
+        }
+        return code;
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
@@ -4,4 +4,5 @@ public interface MailService {
     Boolean sendEmailCertificationMail(Long memberId, String emailAddress);
     Boolean checkMailDomain(String emailAddress);
     String checkEmailCertificationCode(Long memberId, String certificationCode);
+    void sendCoolSmsBalanceMessage(Long balance);
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
@@ -50,4 +50,9 @@ public class MailServiceImpl implements MailService {
         redisMailCertCodeRepository.deleteById(memberId);
         return certCodeEntity.getEmailAddress();
     }
+
+    @Override
+    public void sendCoolSmsBalanceMessage(Long balance) {
+        mailUtil.sendEmailCoolSmsBalanceMail(balance);
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
@@ -3,6 +3,7 @@ package com.modutaxi.api.domain.mail.service;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.model.*;
 import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.util.cert.CertificationCodeUtil;
 import com.modutaxi.api.domain.mail.vo.MailTemplate;
 import jakarta.activation.DataHandler;
 import jakarta.activation.DataSource;
@@ -36,22 +37,13 @@ public class MailUtil {
     }
 
     public String sendEmailCertificationHtmlMail(String receiver) {
-        String certificationCode = generateCertificationCode();
+        String certificationCode = CertificationCodeUtil.generateCertificationCode(5);
         sendSimpleEmailOnlyHtml(
             "[모두의 택시] 인증코드를 안내해드립니다."
             , noReplySender
             , MailTemplate.getCertMailContent(receiver, certificationCode)
             , receiver);
         return certificationCode;
-    }
-
-    private String generateCertificationCode() {
-        final String candidateChars = "1234567890";
-        String code = "";
-        for (int i = 0; i < 5; i++) {
-            code += candidateChars.charAt((int) (Math.random() * candidateChars.length()));
-        }
-        return code;
     }
 
     private SendEmailResult sendSimpleEmailOnlyHtml(String title, String sender, String htmlContent, String receiver) {

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Component;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Properties;
 
 import static com.modutaxi.api.common.exception.errorcode.MailErrorCode.SES_SERVER_ERROR;
@@ -30,6 +31,8 @@ public class MailUtil {
     private final AmazonSimpleEmailService amazonSimpleEmailService;
     @Value("${mail.sender-address.no-reply}")
     private String noReplySender;
+    @Value("${mail.receiver-address.banker-list}")
+    private List<String> bankerEmailList;
 
     public static Boolean emailAddressFormVerification(String emailAddress) {
         String emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$";
@@ -44,6 +47,17 @@ public class MailUtil {
             , MailTemplate.getCertMailContent(receiver, certificationCode)
             , receiver);
         return certificationCode;
+    }
+
+    public void sendEmailCoolSmsBalanceMail(Long balance) {
+        for (String bankerEmail : bankerEmailList) {
+            sendSimpleEmailOnlyHtml(
+                    "[모두의 택시] Cool SMS 잔액 부족"
+                    , noReplySender
+                    , String.format("Cool SMS의 잔액이 %s원 남았습니다. 요금을 충전하세요.", balance)
+                    , bankerEmail
+            );
+        }
     }
 
     private SendEmailResult sendSimpleEmailOnlyHtml(String title, String sender, String htmlContent, String receiver) {

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -4,7 +4,7 @@ import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmMailCertificationReqeust;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendMailCertificationRequest;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto.MailResponse;
+import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.service.UpdateMemberService;
@@ -53,7 +53,7 @@ public class UpdateMemberController {
                     "인증메일을 요청한 메일 주소로 인증 메일을 발송합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "메일 발송 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailResponse.class))),
+            @ApiResponse(responseCode = "200", description = "메일 발송 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CertificationResponse.class))),
             @ApiResponse(responseCode = "400", description = "메일 발송 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailErrorCode.class), examples = {
                     @ExampleObject(name = "MAIL_001", description = "메일 발송 단계에서 실패했습니다.", value = """
                             {
@@ -96,7 +96,7 @@ public class UpdateMemberController {
             })),
     })
     @PostMapping("/mail/certificate")
-    public ResponseEntity<MailResponse> sendEmailCertificationMail(
+    public ResponseEntity<CertificationResponse> sendEmailCertificationMail(
             @CurrentMember Member member,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = SendMailCertificationRequest.class)))
             @RequestBody SendMailCertificationRequest request
@@ -114,7 +114,7 @@ public class UpdateMemberController {
                     "인증코드를 인증합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "메일 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailResponse.class))),
+            @ApiResponse(responseCode = "200", description = "메일 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CertificationResponse.class))),
             @ApiResponse(responseCode = "400", description = "메일 인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MailErrorCode.class), examples = {
                     @ExampleObject(name = "MAIL_001", description = "메일 발송 단계에서 실패했습니다.", value = """
                             {
@@ -143,7 +143,7 @@ public class UpdateMemberController {
             })),
     })
     @PostMapping("/mail/confirm")
-    public ResponseEntity<MailResponse> confirmEmailCertification(
+    public ResponseEntity<CertificationResponse> confirmEmailCertification(
             @CurrentMember Member member,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(schema = @Schema(implementation = ConfirmMailCertificationReqeust.class)))
             @RequestBody ConfirmMailCertificationReqeust request) {

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -4,6 +4,7 @@ import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.common.exception.errorcode.SmsErrorCode;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmMailCertificationReqeust;
+import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmSmsCertificationReqeust;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendMailCertificationRequest;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendSmsCertificationRequest;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
@@ -182,5 +183,49 @@ public class UpdateMemberController {
     @PostMapping("/sms/certificate")
     public ResponseEntity<CertificationResponse> sendSmsCertification(@RequestBody SendSmsCertificationRequest request) {
         return ResponseEntity.ok(updateMemberService.sendSmsCertification(request.getKey(), request.getPhoneNumber()));
+    }
+
+    @Operation(
+            summary = "SMS 인증 확인",
+            description = "수신한 SMS 인증 코드를 인증합니다.<br>로그인 시도 실패시 발급된 key, 인증번호 발급에 사용한 휴대폰 번호, 인증번호를 입력해주세요.<br>휴대전화 번호의 형식은 010-1234-5678 과 같이 '-'와 함께 요청해야하며, 인증번호는 6자리 숫자입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "문자 인증 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CertificationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "문자 인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SmsErrorCode.class), examples = {
+                    @ExampleObject(name = "SMS_001", description = "로그인 시도 실패시 발급된 key로의 인증번호 미발급 또는 인증번호 만료", value = """
+                            {
+                                "errorCode": "SMS_001",
+                                "message": "인증번호가 만료되었습니다."
+                            }
+                            """),
+                    @ExampleObject(name = "SMS_002", description = "인증 수신 휴대전화 번호와 인증 번호화 함께 보낸 휴대전화 번호의 불일치", value = """
+                            {
+                                "errorCode": "SMS_002",
+                                "message": "인증번호를 요청한 번호와 일치하지 않습니다."
+                            }
+                            """),
+                    @ExampleObject(name = "SMS_003", description = "인증번호 불일치", value = """
+                            {
+                                "errorCode": "SMS_003",
+                                "message": "인증번호가 일치하지 않습니다."
+                            }
+                            """),
+                    @ExampleObject(name = "SMS_006", description = "휴대전화 번호 패턴 불일치", value = """
+                            {
+                                "errorCode": "SMS_006",
+                                "message": "유효하지 않은 전화번호 형식입니다."
+                            }
+                            """),
+                    @ExampleObject(name = "SMS_007", description = "인증번호 패턴 불일치", value = """
+                            {
+                                "errorCode": "SMS_007",
+                                "message": "유효하지 않은 인증코드 형식입니다."
+                            }
+                            """),
+            }))
+    })
+    @PostMapping("/sms/confirm")
+    public ResponseEntity<CertificationResponse> confirmSmsCertification(@RequestBody ConfirmSmsCertificationReqeust request) {
+        return ResponseEntity.ok(updateMemberService.checkSmsCertificationCode(request.getKey(), request.getPhoneNumber(), request.getCertificationCode()));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
@@ -50,4 +50,16 @@ public class MemberRequestDto {
         @Schema(description = "인증번호를 받을 전화번호")
         private String phoneNumber;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ConfirmSmsCertificationReqeust {
+        @Schema(description = "회원가입 시 발급받은 키")
+        private String key;
+        @Schema(description = "인증번호를 받은 전화번호")
+        private String phoneNumber;
+        @Schema(description = "인증번호")
+        private String certificationCode;
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
@@ -40,4 +40,14 @@ public class MemberRequestDto {
         @Schema(example = "12345", description = "인증 메일로 받은 인증 코드")
         private String certCode;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SendSmsCertificationRequest {
+        @Schema(description = "회원가입 시 발급받은 키")
+        private String key;
+        @Schema(description = "인증번호를 받을 전화번호")
+        private String phoneNumber;
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -15,8 +15,8 @@ public class MemberResponseDto {
 
     @Getter
     @AllArgsConstructor
-    public static class MailResponse {
-        @Schema(example = "true", description = "메일 API 성공 여부")
+    public static class CertificationResponse {
+        @Schema(example = "true", description = "API 성공 여부")
         private Boolean isConfirm;
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisSnsIdRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisSnsIdRepository.java
@@ -4,4 +4,5 @@ package com.modutaxi.api.domain.member.repository;
 public interface RedisSnsIdRepository {
     String save(String snsId);
     String findAndDeleteById(String key);
+    String findByKey(String key);
 }

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisSnsIdRepositoryImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisSnsIdRepositoryImpl.java
@@ -39,4 +39,9 @@ public class RedisSnsIdRepositoryImpl extends BaseRedisRepository implements Ser
     public String findAndDeleteById(String key) {
         return valueOperations.getAndDelete(generateGlobalKey(key));
     }
+
+    @Override
+    public String findByKey(String key) {
+        return valueOperations.get(generateGlobalKey(key));
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -66,4 +66,8 @@ public class UpdateMemberService {
     public CertificationResponse sendSmsCertification(String signupKey, String phoneNumber) {
         return new CertificationResponse(smsService.sendCertificationCode(signupKey, phoneNumber));
     }
+
+    public CertificationResponse checkSmsCertificationCode(String signupKey, String phoneNumber, String certificationCode) {
+        return new CertificationResponse(smsService.checkSmsCertificationCode(signupKey, phoneNumber, certificationCode));
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -5,7 +5,7 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.domain.mail.service.MailService;
 import com.modutaxi.api.domain.mail.service.MailUtil;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto.MailResponse;
+import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.entity.Role;
@@ -29,7 +29,7 @@ public class UpdateMemberService {
         return jwtTokenProvider.generateToken(memberId);
     }
 
-    public MailResponse sendEmailCertificationMail(Long memberId, String receiver) {
+    public CertificationResponse sendEmailCertificationMail(Long memberId, String receiver) {
         // 이메일 형식 체크
         if (!mailUtil.emailAddressFormVerification(receiver)) {
             throw new BaseException(MailErrorCode.INVALID_EMAIL_FORM);
@@ -41,17 +41,17 @@ public class UpdateMemberService {
         // 이메일 중복 체크
         getNotCertificatedMember(memberId, receiver);
         // 이메일 발송
-        return new MailResponse(mailService.sendEmailCertificationMail(memberId, receiver));
+        return new CertificationResponse(mailService.sendEmailCertificationMail(memberId, receiver));
     }
 
     @Transactional
-    public MailResponse checkEmailCertificationCode(Long memberId, String certificationCode) {
+    public CertificationResponse checkEmailCertificationCode(Long memberId, String certificationCode) {
         String email = mailService.checkEmailCertificationCode(memberId, certificationCode);
         // 이메일 중복 체크
         getNotCertificatedMember(memberId, email);
         Member member = memberRepository.findByIdAndStatusTrue(memberId).get();
         member.certificateEmail(email);
-        return new MailResponse(true);
+        return new CertificationResponse(true);
     }
 
     private void getNotCertificatedMember(Long memberId, String email) {

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -10,6 +10,7 @@ import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.entity.Role;
 import com.modutaxi.api.domain.member.repository.MemberRepository;
+import com.modutaxi.api.domain.sms.service.SmsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class UpdateMemberService {
     private final MemberRepository memberRepository;
     private final MailService mailService;
     private final MailUtil mailUtil;
+    private final SmsService smsService;
 
     public TokenResponse refreshAccessToken(Long memberId) {
         return jwtTokenProvider.generateToken(memberId);
@@ -59,5 +61,9 @@ public class UpdateMemberService {
         if (member.isEmpty()) return;
         if (member.get().getId() == memberId) throw new BaseException(MailErrorCode.ALREADY_CERTIFIED_EMAIL);
         throw new BaseException(MailErrorCode.USED_EMAIL);
+    }
+
+    public CertificationResponse sendSmsCertification(String signupKey, String phoneNumber) {
+        return new CertificationResponse(smsService.sendCertificationCode(signupKey, phoneNumber));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/sms/dao/SmsCertCodeEntity.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/dao/SmsCertCodeEntity.java
@@ -1,0 +1,15 @@
+package com.modutaxi.api.domain.sms.dao;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class SmsCertCodeEntity {
+    private String certificationCode;
+    private String phoneNumber;
+    private LocalDateTime createdAt;
+    private String messageId;
+}

--- a/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepository.java
@@ -5,4 +5,5 @@ import com.modutaxi.api.domain.sms.dao.SmsCertCodeEntity;
 public interface RedisSmsCertificationCodeRepository {
     Boolean save(String signupKey, String phoneNumber, String certificationCode, String messageId);
     SmsCertCodeEntity findById(String signupKey);
+    SmsCertCodeEntity findAndDeleteById(String signupKey);
 }

--- a/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepository.java
@@ -1,0 +1,8 @@
+package com.modutaxi.api.domain.sms.repository;
+
+import com.modutaxi.api.domain.sms.dao.SmsCertCodeEntity;
+
+public interface RedisSmsCertificationCodeRepository {
+    Boolean save(String signupKey, String phoneNumber, String certificationCode, String messageId);
+    SmsCertCodeEntity findById(String signupKey);
+}

--- a/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepositoryImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.modutaxi.api.domain.sms.repository;
+
+import com.modutaxi.api.common.config.redis.BaseRedisRepository;
+import com.modutaxi.api.domain.sms.dao.SmsCertCodeEntity;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisSmsCertificationCodeRepositoryImpl extends BaseRedisRepository implements Serializable, RedisSmsCertificationCodeRepository {
+    private final RedisTemplate<String, SmsCertCodeEntity> redisTemplate;
+    private ValueOperations<String, SmsCertCodeEntity> valueOperations;
+    @Value("${sms.cert-expire-minutes}")
+    private Integer certSmsExpireMinutes;
+
+    @PostConstruct
+    protected void init() {
+        classInstance = RedisSmsCertificationCodeRepositoryImpl.class;
+        valueOperations = redisTemplate.opsForValue();
+    }
+
+    @Override
+    public Boolean save(String signupKey, String phoneNumber, String certificationCode, String messageId) {
+        String key = generateGlobalKey(signupKey);
+        Duration timeoutDuration = Duration.ofMinutes(certSmsExpireMinutes);
+        SmsCertCodeEntity smsCertCodeEntity = new SmsCertCodeEntity(certificationCode, phoneNumber, LocalDateTime.now(), messageId);
+        valueOperations.set(key, smsCertCodeEntity, timeoutDuration);
+        return true;
+    }
+
+    @Override
+    public SmsCertCodeEntity findById(String signupKey) {
+        return valueOperations.get(generateGlobalKey(signupKey));
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepositoryImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/repository/RedisSmsCertificationCodeRepositoryImpl.java
@@ -40,4 +40,9 @@ public class RedisSmsCertificationCodeRepositoryImpl extends BaseRedisRepository
     public SmsCertCodeEntity findById(String signupKey) {
         return valueOperations.get(generateGlobalKey(signupKey));
     }
+
+    @Override
+    public SmsCertCodeEntity findAndDeleteById(String signupKey) {
+        return valueOperations.getAndDelete(generateGlobalKey(signupKey));
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/sms/service/SmsService.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/service/SmsService.java
@@ -1,0 +1,8 @@
+package com.modutaxi.api.domain.sms.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+public interface SmsService {
+    Boolean sendCertificationCode(String signupKey, String phoneNumber);
+}

--- a/src/main/java/com/modutaxi/api/domain/sms/service/SmsService.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/service/SmsService.java
@@ -1,8 +1,6 @@
 package com.modutaxi.api.domain.sms.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 public interface SmsService {
     Boolean sendCertificationCode(String signupKey, String phoneNumber);
+    Boolean checkSmsCertificationCode(String signupKey, String phoneNumber, String certificationCode);
 }

--- a/src/main/java/com/modutaxi/api/domain/sms/service/SmsServiceCoolSmsImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/service/SmsServiceCoolSmsImpl.java
@@ -1,0 +1,122 @@
+package com.modutaxi.api.domain.sms.service;
+
+import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.exception.errorcode.SmsErrorCode;
+import com.modutaxi.api.common.util.cert.CertificationCodeUtil;
+import com.modutaxi.api.domain.mail.service.MailService;
+import com.modutaxi.api.domain.sms.dao.SmsCertCodeEntity;
+import com.modutaxi.api.domain.sms.repository.RedisSmsCertificationCodeRepository;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Balance;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.MessageListRequest;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.MessageListResponse;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+public class SmsServiceCoolSmsImpl implements SmsService {
+
+    private final DefaultMessageService messageService;
+    private final String sender;
+    private final MailService mailService;
+    private final RedisSmsCertificationCodeRepository redisSmsCertificationCodeRepository;
+    private final Integer certSmsRestrictionSeconds;
+    private final Integer certCodeLength;
+    private final Integer checkBalanceThreshold;
+
+
+    public SmsServiceCoolSmsImpl(
+            MailService mailService,
+            RedisSmsCertificationCodeRepository redisSmsCertificationCodeRepository,
+            @Value("${api.cool-sms.api-key}") String apiKey,
+            @Value("${api.cool-sms.api-secret}") String apiSecretKey,
+            @Value("${api.cool-sms.checkBalanceThreshold}") Integer checkBalanceThreshold,
+            @Value("${sms.cert-sms-sender}") String sender,
+            @Value("${sms.cert-sms-restriction-seconds}") Integer certSmsRestrictionSeconds,
+            @Value("${sms.cert-code-length}") Integer certCodeLength
+    ) {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecretKey, "https://api.coolsms.co.kr");
+        this.sender = sender;
+        this.mailService = mailService;
+        this.redisSmsCertificationCodeRepository = redisSmsCertificationCodeRepository;
+        this.checkBalanceThreshold = checkBalanceThreshold;
+        this.certSmsRestrictionSeconds = certSmsRestrictionSeconds;
+        this.certCodeLength = certCodeLength;
+    }
+
+    public Boolean sendCertificationCode(String signupKey, String phoneNumber) {
+        phoneNumber = checkPhoneNumberPattern(phoneNumber);
+        SmsCertCodeEntity smsCertCodeEntity = redisSmsCertificationCodeRepository.findById(signupKey);
+        if (smsCertCodeEntity != null) {
+            getPrevMessage(phoneNumber, smsCertCodeEntity.getMessageId());
+            if (smsCertCodeEntity.getPhoneNumber().equals(phoneNumber) &&
+                    smsCertCodeEntity.getCreatedAt().plusSeconds(certSmsRestrictionSeconds).isAfter(LocalDateTime.now())) {
+                throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_ALREADY_SENT);
+            }
+        }
+        String certificationCode = CertificationCodeUtil.generateCertificationCode(certCodeLength);
+        String messageId = sendOne(phoneNumber, String.format("[모두의택시] 인증번호는 [%s]입니다.", certificationCode));
+        redisSmsCertificationCodeRepository.save(signupKey, phoneNumber, certificationCode, messageId);
+        checkBalance();
+        return true;
+    }
+
+    private String checkPhoneNumberPattern(String phoneNumber) {
+        String REGEXP_ONLY_NUM = "^01([0|1|6|7|8|9])-([0-9]{3,4})-([0-9]{4})+$";
+        if (!phoneNumber.matches(REGEXP_ONLY_NUM)) {
+            throw new BaseException(SmsErrorCode.INVALID_PHONE_NUMBER_PATTERN);
+        }
+        String[] numbers = phoneNumber.split("-");
+        return numbers[0] + numbers[1] + numbers[2];
+    }
+
+    private void getPrevMessage(String phoneNumber, String messageId) {
+        MessageListRequest request = new MessageListRequest();
+        request.setMessageId(messageId);
+        request.setLimit(1);
+        request.setTo(phoneNumber);
+        request.setFrom(sender);
+        request.setType("SMS");
+        request.getStartDate();
+        MessageListResponse response = messageService.getMessageList(request);
+        String status = response.getMessageList().get(messageId).getStatus();
+        if (status.equals("PENDING")) {
+            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_SENDING);
+        } else if (status.equals("SENDING")) {
+            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_ALREADY_SENT);
+        } else if (status.equals("COMPLETE")) {
+            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_ALREADY_SENT);
+        } else if (status.equals("FAILED")) {
+            log.warn("[COOL SMS] 메세지 발송에 실패하여 재시도 합니다.");
+        }
+    }
+
+    private String sendOne(String phoneNumber, String text) {
+        Message message = new Message();
+        message.setFrom(sender);
+        message.setTo(phoneNumber);
+        message.setText(text);
+        SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
+        return response.getMessageId();
+    }
+
+    private void checkBalance() {
+        Balance balance = messageService.getBalance();
+        try {
+            if (balance.getPoint().longValue() <= checkBalanceThreshold) {
+                mailService.sendCoolSmsBalanceMessage(balance.getPoint().longValue());
+                log.warn(String.format("[COOL SMS] 잔액이 %s원 남았습니다.", balance));
+            }
+        } catch (NullPointerException e) {
+            log.warn("[COOL SMS] 남은 요금을 확인할 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 요약 🎀
- 전화번호 메시지 인증 구현입니다.

## 상세 내용 🌈
- 인증 번호 생성 로직을 이메일 유틸에서 공통 유틸로 바꿨습니다.
- 이메일과 문자 인증 반환 dto를 통합하였습니다.
- 인증코드 발송 API 구현
  - 회원가입 시 발급받은 key에 대한 검증을 하였습니다.
  - 휴대전화 번호의 형식을 검증하였습니다.
  - 메세지 id를 캐싱하여 보낸 인증 메세지가 발송에 실패하지 않았다면 중복적으로 같은 조건의 많은 문자를 보내지 못하게 했습니다.
  - 문자 발송은 `CoolSMS` 서비스를 이용하였으며, 요금 정책에 따라 `알리고` 를 이용할 가능성도 존재하여 인터페이스와 구현체 형태로 구현하였습니다.
    - `CoolSMS` 는 건당 20원, `알리고`는 건당 8.4원 의 서비스 입니다.
  - 문자 발송 후 `CoolSMS` 잔고가 부족하다면 AWS SNS 서비스를 이용하여 관리자에게 예산 충전 메일이 발송되도록 하였습니다.
<img width="1225" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/240f304f-e97e-4c2c-9e34-54e056053487">

- 인증코드 검증 API 구현
  - 회원가입 시 발급받은 key에 대한 검증을 하였습니다.
  - 휴대전화 번호의 형식을 검증하였습니다.
  - 인증번호의 형식을 검증하였습니다.
<img width="1219" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/7d06c687-92d8-46a3-958a-82e87dc2bdf2">

## 질문 및 이외 사항 🚩
- 문자 발송 형식
  <img width="246" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/05944658-e013-4fbc-b2bc-3623b9be332e">
- 잔고 부족 이메일 형식
  <img width="341" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/0c7b1336-58c5-401e-aa17-a3e36cc3942f">
