### PR TITLE
[MS-98] 방 생성 예외처리

### DIFF
--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
@@ -14,6 +14,7 @@ public enum RoomErrorCode implements ErrorCode {
     BOTH_GENDER("ROOM_004", "성별 제한이 둘 다 설정되어 있습니다.", HttpStatus.CONFLICT),
     DEPARTURE_BEFORE_CURRENT("ROOM_005", "출발 시간은 현재 시간보다 이전일 수 없습니다.", HttpStatus.BAD_REQUEST),
     DEPARTURE_EXCEED_RANGE("ROOM_006", "출발 위치는 대한민국을 벗어날 수 없습니다.", HttpStatus.BAD_REQUEST),
+    POINT_IS_NOT_INDEPENDENT("ROOM_006", "위도와 경도는 한 묶음", HttpStatus.CONFLICT),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/RoomErrorCode.java
@@ -12,6 +12,8 @@ public enum RoomErrorCode implements ErrorCode {
     NOT_ROOM_MANAGER("ROOM_002", "권한이 없는 사용자입니다.", HttpStatus.CONFLICT),
     ALREADY_MEMBER_IS_MANAGER("ROOM_003", "방을 두 개 이상 만들 수 없습니다.", HttpStatus.CONFLICT),
     BOTH_GENDER("ROOM_004", "성별 제한이 둘 다 설정되어 있습니다.", HttpStatus.CONFLICT),
+    DEPARTURE_BEFORE_CURRENT("ROOM_005", "출발 시간은 현재 시간보다 이전일 수 없습니다.", HttpStatus.BAD_REQUEST),
+    DEPARTURE_EXCEED_RANGE("ROOM_006", "출발 위치는 대한민국을 벗어날 수 없습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/GetRoomController.java
@@ -42,7 +42,7 @@ public class GetRoomController {
     }
 
     @Operation(summary = "경로를 제외한 방 리스트 조회",
-            description = "방 리스트를 조회합니다.<br><br>**spotId**(찾으려는 거점 id, 필수 x), **isImminent**(마감 임박 여부), **roomTags**(찾으려는 방 태그, 필수 x)를 함께 보내주세요.<br><br> **roomTag** : 'ONLY_WOMAN', 'ONLY_MAN', 'MANNER', 'QUIET', 'STUDENT_CERTIFICATION'<br><br>**page(0 ~ )** : 페이지 번호<br><br>**size(1 ~ )** : 사이즈")
+            description = "방 리스트를 조회합니다.<br><br>**spotId**(찾으려는 거점 id, 필수 x), **isImminent**(마감 임박 여부), **roomTags**(찾으려는 방 태그, 필수 x)를 함께 보내주세요.<br><br> **roomTag** : 'ONLY_WOMAN', 'MANNER', 'STUDENT_CERTIFICATION'<br><br>**page(0 ~ )** : 페이지 번호<br><br>**size(1 ~ )** : 사이즈")
     @GetMapping("/list")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "방 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = RoomSimpleResponse.class))),

--- a/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
@@ -30,7 +30,8 @@ public class RegisterRoomController {
     @Operation(summary = "모집방 생성",
         description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
             + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890, 37.513137)**")
+            + "\n\n\n**longitude**: 126.65464\n\n\n"
+            + "**latitude**: 37.45169")
     @PostMapping
     public ResponseEntity<RoomDetailResponse> createRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
@@ -29,8 +29,8 @@ public class RegisterRoomController {
      */
     @Operation(summary = "모집방 생성",
         description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
-            + "ONLY\\_WOMAN, ONLY\\_MAN, REGARDLESS\\_OF\\_GENDER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890,37.513137)**")
+            + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
+            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890, 37.513137)**")
     @PostMapping
     public ResponseEntity<RoomDetailResponse> createRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
@@ -30,8 +30,8 @@ public class UpdateRoomController {
      */
     @Operation(summary = "모집방 업데이트",
         description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
-            + "ONLY\\_WOMAN, ONLY\\_MAN, REGARDLESS\\_OF\\_GENDER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890,37.513137)**")
+            + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
+            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890, 37.513137)**")
     @PatchMapping("/{id}")
     public ResponseEntity<RoomDetailResponse> updateRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
@@ -31,7 +31,8 @@ public class UpdateRoomController {
     @Operation(summary = "모집방 업데이트",
         description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
             + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**departurePoint(X:경도, Y:위도)**\n\n**예시: departurePoint(126.678890, 37.513137)**")
+            + "\n\n\n**longitude**: 126.65464\n\n\n"
+            + "**latitude**: 37.45169")
     @PatchMapping("/{id}")
     public ResponseEntity<RoomDetailResponse> updateRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
@@ -2,6 +2,7 @@ package com.modutaxi.api.domain.room.dto;
 
 import com.modutaxi.api.domain.spot.entity.Spot;
 import com.modutaxi.api.domain.room.entity.Room;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,9 @@ public class RoomInternalDto {
 
         private int roomTagBitMask;
 
-        private Point departurePoint;
+        private Float longitude;
+
+        private Float latitude;
 
         private LocalDateTime departureTime;
 
@@ -32,13 +35,11 @@ public class RoomInternalDto {
         private long duration;
 
         public static InternalUpdateRoomDto toDto(Room room) {
-            GeometryFactory geometryFactory = new GeometryFactory();
-            Coordinate coordinate = new Coordinate(room.getDeparturePoint().getX(), room.getDeparturePoint().getY());
-            Point point = geometryFactory.createPoint(coordinate);
             return InternalUpdateRoomDto.builder()
                 .spot(room.getSpot())
                 .roomTagBitMask(room.getRoomTagBitMask())
-                .departurePoint(point)
+                .longitude((float) room.getDeparturePoint().getX())
+                .latitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
@@ -22,9 +22,9 @@ public class RoomInternalDto {
 
         private int roomTagBitMask;
 
-        private Float longitude;
+        private Float departureLongitude;
 
-        private Float latitude;
+        private Float departureLatitude;
 
         private LocalDateTime departureTime;
 
@@ -38,8 +38,8 @@ public class RoomInternalDto {
             return InternalUpdateRoomDto.builder()
                 .spot(room.getSpot())
                 .roomTagBitMask(room.getRoomTagBitMask())
-                .longitude((float) room.getDeparturePoint().getX())
-                .latitude((float) room.getDeparturePoint().getY())
+                .departureLongitude((float) room.getDeparturePoint().getX())
+                .departureLatitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -22,7 +22,11 @@ public class RoomRequestDto {
 
         private List<RoomTagBitMask> roomTagBitMask;
 
-        private Point departurePoint;
+        @Schema(example = "126.65464", description = "경도")
+        private Float longitude;
+
+        @Schema(example = "37.45169", description = "위도")
+        private Float latitude;
 
         private LocalDateTime departureTime;
 
@@ -37,7 +41,11 @@ public class RoomRequestDto {
 
         private List<RoomTagBitMask> roomTagBitMask;
 
-        private Point departurePoint;
+        @Schema(example = "126.65464", description = "경도")
+        private Float longitude;
+
+        @Schema(example = "37.45169", description = "위도")
+        private Float latitude;
 
         private LocalDateTime departureTime;
 

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -22,11 +22,11 @@ public class RoomRequestDto {
 
         private List<RoomTagBitMask> roomTagBitMask;
 
-        @Schema(example = "126.65464", description = "경도")
-        private Float longitude;
+        @Schema(example = "126.65464", description = "출발지 경도")
+        private Float departureLongitude;
 
-        @Schema(example = "37.45169", description = "위도")
-        private Float latitude;
+        @Schema(example = "37.45169", description = "출발지 위도")
+        private Float departureLatitude;
 
         private LocalDateTime departureTime;
 
@@ -41,11 +41,11 @@ public class RoomRequestDto {
 
         private List<RoomTagBitMask> roomTagBitMask;
 
-        @Schema(example = "126.65464", description = "경도")
-        private Float longitude;
+        @Schema(example = "126.65464", description = "출발지 경도")
+        private Float departureLongitude;
 
-        @Schema(example = "37.45169", description = "위도")
-        private Float latitude;
+        @Schema(example = "37.45169", description = "출발지 위도")
+        private Float departureLatitude;
 
         private LocalDateTime departureTime;
 

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -20,8 +20,6 @@ public class RoomRequestDto {
 
         private Long spotId;
 
-        private String description;
-
         private List<RoomTagBitMask> roomTagBitMask;
 
         private Point departurePoint;
@@ -36,8 +34,6 @@ public class RoomRequestDto {
     public static class UpdateRoomRequest {
 
         private Long spotId;
-
-        private String description;
 
         private List<RoomTagBitMask> roomTagBitMask;
 

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -27,10 +27,11 @@ public class RoomResponseDto {
 
         private List<RoomTagBitMask> roomTagBitMaskList;
 
-        @Schema(example = "126.68045", description = "경도")
-        private Float longitude;
-        @Schema(example = "37.46504", description = "위도")
-        private Float latitude;
+        @Schema(example = "126.65464", description = "출발지 경도")
+        private Float departureLongitude;
+
+        @Schema(example = "37.45169", description = "출발지 위도")
+        private Float departureLatitude;
 
         private LocalDateTime departureTime;
 
@@ -47,8 +48,8 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .spotId(room.getSpot().getId())
                 .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .longitude((float) room.getDeparturePoint().getX())
-                .latitude((float) room.getDeparturePoint().getY())
+                .departureLongitude((float) room.getDeparturePoint().getX())
+                .departureLatitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())
@@ -69,10 +70,11 @@ public class RoomResponseDto {
 
         private List<RoomTagBitMask> roomTagBitMaskList;
 
-        @Schema(example = "126.68045", description = "경도")
-        private Float longitude;
-        @Schema(example = "37.46504", description = "위도")
-        private Float latitude;
+        @Schema(example = "126.65464", description = "출발지 경도")
+        private Float departureLongitude;
+
+        @Schema(example = "37.45169", description = "출발지 위도")
+        private Float departureLatitude;
 
         private LocalDateTime departureTime;
 
@@ -87,8 +89,8 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .spotId(room.getSpot().getId())
                 .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .longitude((float) room.getDeparturePoint().getX())
-                .latitude((float) room.getDeparturePoint().getY())
+                .departureLongitude((float) room.getDeparturePoint().getX())
+                .departureLatitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())
@@ -103,10 +105,10 @@ public class RoomResponseDto {
 
         @Schema(example = "2", description = "방 id")
         private Long id;
-        @Schema(example = "126.68045", description = "경도")
-        private Float longitude;
-        @Schema(example = "37.46504", description = "위도")
-        private Float latitude;
+        @Schema(example = "126.65464", description = "출발지 경도")
+        private Float departureLongitude;
+        @Schema(example = "37.45169", description = "출발지 위도")
+        private Float departureLatitude;
         @Schema(example = "주안역", description = "거점 이름")
         private String spotName;
     }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -27,7 +27,10 @@ public class RoomResponseDto {
 
         private List<RoomTagBitMask> roomTagBitMaskList;
 
-        private Point departurePoint;
+        @Schema(example = "126.68045", description = "경도")
+        private Float longitude;
+        @Schema(example = "37.46504", description = "위도")
+        private Float latitude;
 
         private LocalDateTime departureTime;
 
@@ -44,7 +47,8 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .spotId(room.getSpot().getId())
                 .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .departurePoint(new Point(room.getDeparturePoint().getX(), room.getDeparturePoint().getY()))
+                .longitude((float) room.getDeparturePoint().getX())
+                .latitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())
@@ -65,7 +69,10 @@ public class RoomResponseDto {
 
         private List<RoomTagBitMask> roomTagBitMaskList;
 
-        private Point departurePoint;
+        @Schema(example = "126.68045", description = "경도")
+        private Float longitude;
+        @Schema(example = "37.46504", description = "위도")
+        private Float latitude;
 
         private LocalDateTime departureTime;
 
@@ -80,7 +87,8 @@ public class RoomResponseDto {
                 .roomId(room.getId())
                 .spotId(room.getSpot().getId())
                 .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .departurePoint(new Point(room.getDeparturePoint().getX(), room.getDeparturePoint().getY()))
+                .longitude((float) room.getDeparturePoint().getX())
+                .latitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
                 .wishHeadcount(room.getWishHeadcount())
                 .duration(room.getDuration())
@@ -92,6 +100,7 @@ public class RoomResponseDto {
     @Getter
     @AllArgsConstructor
     public static class SearchWithRadiusResponse {
+
         @Schema(example = "2", description = "방 id")
         private Long id;
         @Schema(example = "126.68045", description = "경도")
@@ -105,6 +114,7 @@ public class RoomResponseDto {
     @Getter
     @AllArgsConstructor
     public static class SearchWithRadiusResponses {
+
         @Schema(description = "방 리스트")
         List<SearchWithRadiusResponse> rooms;
     }

--- a/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
+++ b/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
 @Getter
@@ -65,7 +67,10 @@ public class Room extends BaseTime {
     public void update(InternalUpdateRoomDto updateRoomDto) {
         this.spot = updateRoomDto.getSpot();
         this.roomTagBitMask = updateRoomDto.getRoomTagBitMask();
-        this.departurePoint = updateRoomDto.getDeparturePoint();
+        GeometryFactory geometryFactory = new GeometryFactory();
+        Coordinate coordinate
+            = new Coordinate(updateRoomDto.getLongitude(), updateRoomDto.getLatitude());
+        this.departurePoint = geometryFactory.createPoint(coordinate);
         this.departureTime = updateRoomDto.getDepartureTime();
         this.wishHeadcount = updateRoomDto.getWishHeadcount();
         this.expectedCharge = updateRoomDto.getExpectedCharge();

--- a/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
+++ b/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
@@ -69,7 +69,7 @@ public class Room extends BaseTime {
         this.roomTagBitMask = updateRoomDto.getRoomTagBitMask();
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate
-            = new Coordinate(updateRoomDto.getLongitude(), updateRoomDto.getLatitude());
+            = new Coordinate(updateRoomDto.getDepartureLongitude(), updateRoomDto.getDepartureLatitude());
         this.departurePoint = geometryFactory.createPoint(coordinate);
         this.departureTime = updateRoomDto.getDepartureTime();
         this.wishHeadcount = updateRoomDto.getWishHeadcount();

--- a/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 import com.modutaxi.api.domain.spot.entity.Spot;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,7 +19,7 @@ public class RoomMapper {
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate = new Coordinate(departurePoint.getX(), departurePoint.getY());
-        org.locationtech.jts.geom.Point point = geometryFactory.createPoint(coordinate);
+        Point point = geometryFactory.createPoint(coordinate);
         return Room.builder()
             .spot(spot)
             .roomManager(member)

--- a/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
@@ -14,11 +14,17 @@ import org.springframework.stereotype.Component;
 public class RoomMapper {
 
     public static Room toEntity(
-        Member member, Spot spot, int expectedCharge, long duration,
-        int roomTagBitMask, Point departurePoint, LocalDateTime departureTime
+        Member member,
+        Spot spot,
+        int expectedCharge,
+        long duration,
+        int roomTagBitMask,
+        float departureLongitude,
+        float departureLatitude,
+        LocalDateTime departureTime
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
-        Coordinate coordinate = new Coordinate(departurePoint.getX(), departurePoint.getY());
+        Coordinate coordinate = new Coordinate(departureLongitude, departureLatitude);
         Point point = geometryFactory.createPoint(coordinate);
         return Room.builder()
             .spot(spot)

--- a/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
@@ -34,6 +34,11 @@ public class RegisterRoomService {
     private final GetTaxiInfoService getTaxiInfoService;
     private final RegisterTaxiInfoService registerTaxiInfoService;
 
+    private static final float MIN_LATITUDE = 33;
+    private static final float MAX_LATITUDE = 40;
+    private static final float MIN_LONGITUDE = 124;
+    private static final float MAX_LONGITUDE = 132;
+
     @Transactional
     public RoomDetailResponse createRoom(Member member, CreateRoomRequest createRoomRequest) {
 
@@ -72,7 +77,7 @@ public class RegisterRoomService {
         return RoomDetailResponse.toDto(room, path);
     }
 
-    private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest){
+    private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {
         if (roomRepository.existsRoomByRoomManagerId(member.getId())) {
             throw new BaseException(RoomErrorCode.ALREADY_MEMBER_IS_MANAGER);
         }
@@ -82,13 +87,14 @@ public class RegisterRoomService {
             throw new BaseException(RoomErrorCode.BOTH_GENDER);
         }
 
-        if(createRoomRequest.getDepartureTime().isBefore(LocalDateTime.now())){
+        if (createRoomRequest.getDepartureTime().isBefore(LocalDateTime.now())) {
             throw new BaseException(RoomErrorCode.DEPARTURE_BEFORE_CURRENT);
         }
 
         Float longitude = (float) createRoomRequest.getDeparturePoint().getX();
-        Float latitude= (float) createRoomRequest.getDeparturePoint().getY();
-        if(latitude < 33 || latitude > 40 || longitude <124 || longitude > 132){
+        Float latitude = (float) createRoomRequest.getDeparturePoint().getY();
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
+            || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
             throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);
         }
     }

--- a/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
@@ -22,9 +22,6 @@ import com.mongodb.client.model.geojson.LineString;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -53,8 +50,8 @@ public class RegisterRoomService {
 
         //시작 지점, 목표 지점 설정
         String startCoordinate =
-            NaverMapConverter.coordinateToString(createRoomRequest.getLongitude(),
-                createRoomRequest.getLatitude());
+            NaverMapConverter.coordinateToString(createRoomRequest.getDepartureLongitude(),
+                createRoomRequest.getDepartureLatitude());
 
         String goalCoordinate =
             NaverMapConverter.coordinateToString(spot.getSpotPoint().getX(),
@@ -67,18 +64,12 @@ public class RegisterRoomService {
 
         long duration = taxiInfo.get("duration").asLong();
 
-        GeometryFactory geometryFactory = new GeometryFactory();
-
-        Coordinate coordinate
-            = new Coordinate(createRoomRequest.getLongitude(), createRoomRequest.getLatitude());
-
-        Point point = geometryFactory.createPoint(coordinate);
-
         Room room = RoomMapper.toEntity(member, spot,
             expectedCharge, duration,
             convertRoomTagListToBitMask(
                 createRoomRequest.getRoomTagBitMask()),
-            point, createRoomRequest.getDepartureTime()
+            createRoomRequest.getDepartureLongitude(), createRoomRequest.getDepartureLatitude(),
+            createRoomRequest.getDepartureTime()
         );
 
         LineString path = NaverMapConverter.jsonNodeToLineString(taxiInfo.get("path"));
@@ -102,8 +93,8 @@ public class RegisterRoomService {
             throw new BaseException(RoomErrorCode.DEPARTURE_BEFORE_CURRENT);
         }
 
-        Float longitude = createRoomRequest.getLongitude();
-        Float latitude = createRoomRequest.getLatitude();
+        Float longitude = createRoomRequest.getDepartureLongitude();
+        Float latitude = createRoomRequest.getDepartureLatitude();
         if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
             || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
             throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -53,7 +53,6 @@ public class UpdateRoomService {
         InternalUpdateRoomDto newRoomData = validateAndReturnNewDto(oldRoomData, updateRoomRequest);
 
         //TaxiInfo db 업데이트
-        // TODO: 2024/04/05 JPA와 달리 모든 과정이 끝난 후 db에 반영되는 이슈가 있기에 임시 변수 추가
         LineString path = taxiInfo.getPath();
         if (shouldUpdateTaxiInfo(updateRoomRequest)) {
             path = updateTaxiInfo(roomId, newRoomData);
@@ -98,14 +97,17 @@ public class UpdateRoomService {
 
         oldRoomData.setSpot(
             updateRoomRequest.getSpotId() != null ? spotRepository.findById(
-                updateRoomRequest.getSpotId()).orElseThrow(() -> new BaseException(SpotError.SPOT_ID_NOT_FOUND)) : oldRoomData.getSpot());
+                    updateRoomRequest.getSpotId())
+                .orElseThrow(() -> new BaseException(SpotError.SPOT_ID_NOT_FOUND))
+                : oldRoomData.getSpot());
 
-        if(updateRoomRequest.getDeparturePoint() != null)  {
-            GeometryFactory geometryFactory = new GeometryFactory();
-            Coordinate coordinate = new Coordinate(updateRoomRequest.getDeparturePoint().getX(), updateRoomRequest.getDeparturePoint().getY());
-            Point updatedPoint = geometryFactory.createPoint(coordinate);
-            oldRoomData.setDeparturePoint(updatedPoint);
-        }
+        oldRoomData.setLongitude(
+            updateRoomRequest.getLongitude() != null ? updateRoomRequest.getLongitude()
+                : oldRoomData.getLongitude());
+
+        oldRoomData.setLatitude(
+            updateRoomRequest.getLatitude() != null ? updateRoomRequest.getLatitude()
+                : oldRoomData.getLatitude());
 
         return oldRoomData;
     }
@@ -113,8 +115,8 @@ public class UpdateRoomService {
     @Transactional
     public LineString updateTaxiInfo(Long roomId, InternalUpdateRoomDto internalUpdateRoomDto) {
         String startCoordinate =
-            NaverMapConverter.coordinateToString(internalUpdateRoomDto.getDeparturePoint().getX(),
-                internalUpdateRoomDto.getDeparturePoint().getY());
+            NaverMapConverter.coordinateToString(internalUpdateRoomDto.getLongitude(),
+                internalUpdateRoomDto.getLatitude());
 
         String goalCoordinate =
             NaverMapConverter.coordinateToString(
@@ -135,7 +137,7 @@ public class UpdateRoomService {
 
     public boolean shouldUpdateTaxiInfo(UpdateRoomRequest updateRoomRequest) {
         return updateRoomRequest.getSpotId() != null
-                || updateRoomRequest.getDeparturePoint() != null;
+            || updateRoomRequest.getLongitude() != null || updateRoomRequest.getLatitude() != null;
     }
 
     void checkManager(Long managerId, Long memberId) {

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -10,9 +10,11 @@ import com.modutaxi.api.common.exception.errorcode.SpotError;
 import com.modutaxi.api.common.exception.errorcode.TaxiInfoErrorCode;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dto.RoomInternalDto.InternalUpdateRoomDto;
+import com.modutaxi.api.domain.room.dto.RoomRequestDto.CreateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.UpdateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.entity.Room;
+import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
 import com.modutaxi.api.domain.spot.repository.SpotRepository;
 import com.modutaxi.api.domain.taxiinfo.entity.TaxiInfo;
@@ -20,10 +22,8 @@ import com.modutaxi.api.domain.taxiinfo.repository.TaxiInfoMongoRepository;
 import com.modutaxi.api.domain.taxiinfo.service.GetTaxiInfoService;
 import com.mongodb.client.model.geojson.LineString;
 import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -33,8 +33,11 @@ public class UpdateRoomService {
     private final RoomRepository roomRepository;
     private final TaxiInfoMongoRepository taxiInfoMongoRepository;
     private final SpotRepository spotRepository;
-
     private final GetTaxiInfoService getTaxiInfoService;
+    private static final float MIN_LATITUDE = 33;
+    private static final float MAX_LATITUDE = 40;
+    private static final float MIN_LONGITUDE = 124;
+    private static final float MAX_LONGITUDE = 132;
 
     @Transactional
     public RoomDetailResponse updateRoom(Member member, Long roomId,
@@ -76,9 +79,20 @@ public class UpdateRoomService {
         taxiInfoMongoRepository.delete(taxiInfo);
     }
 
+    private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {
+
+        Float longitude = createRoomRequest.getDepartureLongitude();
+        Float latitude = createRoomRequest.getDepartureLatitude();
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
+            || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
+            throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);
+        }
+    }
+
     public InternalUpdateRoomDto validateAndReturnNewDto(InternalUpdateRoomDto oldRoomData,
         UpdateRoomRequest updateRoomRequest) {
 
+        // 태그 업데이트 및 예외처리
         oldRoomData.setRoomTagBitMask(
             RoomTagBitMaskConverter.convertRoomTagListToBitMask(
                 updateRoomRequest.getRoomTagBitMask()) != 0
@@ -87,27 +101,51 @@ public class UpdateRoomService {
                 : oldRoomData.getRoomTagBitMask()
         );
 
+        if (oldRoomData.getRoomTagBitMask() == RoomTagBitMask.ONLY_WOMAN.getValue() + RoomTagBitMask.ONLY_MAN.getValue()) {
+            throw new BaseException(RoomErrorCode.BOTH_GENDER);
+        }
+
+        // 출발시간 업데이트 및 예외처리
         oldRoomData.setDepartureTime(
             updateRoomRequest.getDepartureTime() != null ? updateRoomRequest.getDepartureTime()
                 : oldRoomData.getDepartureTime());
 
+        if (oldRoomData.getDepartureTime().isBefore(LocalDateTime.now())) {
+            throw new BaseException(RoomErrorCode.DEPARTURE_BEFORE_CURRENT);
+        }
+
+        // 인원수 업데이트
         oldRoomData.setWishHeadcount(
             updateRoomRequest.getWishHeadcount() != 0 ? updateRoomRequest.getWishHeadcount()
                 : oldRoomData.getWishHeadcount());
 
+        // 목적지 업데이트
         oldRoomData.setSpot(
             updateRoomRequest.getSpotId() != null ? spotRepository.findById(
                     updateRoomRequest.getSpotId())
                 .orElseThrow(() -> new BaseException(SpotError.SPOT_ID_NOT_FOUND))
                 : oldRoomData.getSpot());
 
-        oldRoomData.setLongitude(
-            updateRoomRequest.getLongitude() != null ? updateRoomRequest.getLongitude()
-                : oldRoomData.getLongitude());
+        // 출발지 업데이트 및 예외처리
+        // 위도, 경도 중에서 값이 하나만 들어왔을 때 예외처리
+        if((updateRoomRequest.getDepartureLatitude() != null && updateRoomRequest.getDepartureLongitude() == null)
+        || (updateRoomRequest.getDepartureLatitude() == null && updateRoomRequest.getDepartureLongitude() != null)){
+            throw new BaseException(RoomErrorCode.POINT_IS_NOT_INDEPENDENT);
+        }
+        oldRoomData.setDepartureLongitude(
+            updateRoomRequest.getDepartureLongitude() != null ? updateRoomRequest.getDepartureLongitude()
+                : oldRoomData.getDepartureLongitude());
 
-        oldRoomData.setLatitude(
-            updateRoomRequest.getLatitude() != null ? updateRoomRequest.getLatitude()
-                : oldRoomData.getLatitude());
+        oldRoomData.setDepartureLatitude(
+            updateRoomRequest.getDepartureLatitude() != null ? updateRoomRequest.getDepartureLatitude()
+                : oldRoomData.getDepartureLatitude());
+
+        Float longitude = oldRoomData.getDepartureLongitude();
+        Float latitude = oldRoomData.getDepartureLatitude();
+        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
+            || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
+            throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);
+        }
 
         return oldRoomData;
     }
@@ -115,8 +153,8 @@ public class UpdateRoomService {
     @Transactional
     public LineString updateTaxiInfo(Long roomId, InternalUpdateRoomDto internalUpdateRoomDto) {
         String startCoordinate =
-            NaverMapConverter.coordinateToString(internalUpdateRoomDto.getLongitude(),
-                internalUpdateRoomDto.getLatitude());
+            NaverMapConverter.coordinateToString(internalUpdateRoomDto.getDepartureLongitude(),
+                internalUpdateRoomDto.getDepartureLatitude());
 
         String goalCoordinate =
             NaverMapConverter.coordinateToString(
@@ -135,12 +173,12 @@ public class UpdateRoomService {
         return path;
     }
 
-    public boolean shouldUpdateTaxiInfo(UpdateRoomRequest updateRoomRequest) {
+    private boolean shouldUpdateTaxiInfo(UpdateRoomRequest updateRoomRequest) {
         return updateRoomRequest.getSpotId() != null
-            || updateRoomRequest.getLongitude() != null || updateRoomRequest.getLatitude() != null;
+            || updateRoomRequest.getDepartureLongitude() != null || updateRoomRequest.getDepartureLatitude() != null;
     }
 
-    void checkManager(Long managerId, Long memberId) {
+    private void checkManager(Long managerId, Long memberId) {
         if (!managerId.equals(memberId)) {
             throw new BaseException(RoomErrorCode.NOT_ROOM_MANAGER);
         }


### PR DESCRIPTION
## 요약 🎀
- 방 생성 예외처리
- RoomRequestDto의 description 필드 삭제

## 상세 내용 🌈
- Room을 생성할 때 검증해야할 요소가 많은 만큼 메서드를 분리하였습니다.
```java
private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {
        if (roomRepository.existsRoomByRoomManagerId(member.getId())) {
            throw new BaseException(RoomErrorCode.ALREADY_MEMBER_IS_MANAGER);
        }

        if (convertRoomTagListToBitMask(createRoomRequest.getRoomTagBitMask())
            == RoomTagBitMask.ONLY_WOMAN.getValue() + RoomTagBitMask.ONLY_MAN.getValue()) {
            throw new BaseException(RoomErrorCode.BOTH_GENDER);
        }

        if (createRoomRequest.getDepartureTime().isBefore(LocalDateTime.now())) {
            throw new BaseException(RoomErrorCode.DEPARTURE_BEFORE_CURRENT);
        }

        Float longitude = (float) createRoomRequest.getDeparturePoint().getX();
        Float latitude = (float) createRoomRequest.getDeparturePoint().getY();
        if (latitude < MIN_LATITUDE || latitude > MAX_LATITUDE
            || longitude < MIN_LONGITUDE || longitude > MAX_LONGITUDE) {
            throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);
        }
    }
```

### 추가된 예외처리
**출발 위치가 대한민국의 범위를 벗어나는 상황에서 예외처리를 해주었습니다.**
- 아래 예시는 대한민국의 북위를 벗어난 북위 41도의 요청에 대한 예외처리입니다.
<img width="741" alt="스크린샷 2024-04-23 오후 6 14 13" src="https://github.com/MODU-TAXI/server-api/assets/100510247/2eadb769-de5d-40b4-8953-0679ef73ae90">


**방 생성 시간보다 출발 시간이 앞선 상황에서 예외처리를 해주었습니다.**
- 아래 예시는 요청 날짜 4/23일보다 앞선 4/22일에 출발하겠다는 요청에 대한 예외처리 예시입니다.
<img width="728" alt="스크린샷 2024-04-23 오후 6 14 40" src="https://github.com/MODU-TAXI/server-api/assets/100510247/76b82063-5789-4034-a7b5-a66ed3c892cc">

## 질문 및 이외 사항 🚩
- 시간과 출발 위치에 대한 예외처리는 보다 구체적인 기획이 결정되면 다시 조정할 예정입니다.

## 리뷰어에게 ✨
- 
