### PR TITLE
[MS-65] 설문조사 API

### DIFF
--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/OnboardingErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/OnboardingErrorCode.java
@@ -1,0 +1,18 @@
+package com.modutaxi.api.common.exception.errorcode;
+
+import com.modutaxi.api.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum OnboardingErrorCode implements ErrorCode {
+
+    EMPTY_ONBOARDING("ONBOARDING_001", "존재하지 않는 설문조사 ID 입니다.", HttpStatus.BAD_REQUEST)
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/modutaxi/api/common/initializer/InitialApplicationListener.java
+++ b/src/main/java/com/modutaxi/api/common/initializer/InitialApplicationListener.java
@@ -1,0 +1,36 @@
+package com.modutaxi.api.common.initializer;
+
+import com.modutaxi.api.domain.onboarding.mapper.OnboardingMapper;
+import com.modutaxi.api.domain.onboarding.repository.OnboardingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class InitialApplicationListener implements
+        ApplicationListener<ContextRefreshedEvent> {
+
+    private final OnboardingRepository onboardingRepository;
+    private final OnboardingMapper onboardingMapper;
+
+    private static final int NUMBER_OF_QUESTION = 2;
+
+    /**
+     * 서버 실행 시 DB에 질문이 존재하지 않는다면 먼저 register 해준다.
+     */
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        for(int i = 1; i <= NUMBER_OF_QUESTION; i++) {
+            if(onboardingRepository.findByQuestionId(i).isEmpty()) {
+                onboardingRepository.save(onboardingMapper.toEntity(i));
+                log.info("InitializingOnboarding: {}", i);
+            }
+        }
+    }
+
+}
+

--- a/src/main/java/com/modutaxi/api/domain/onboarding/controller/RegisterOnboardingController.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/controller/RegisterOnboardingController.java
@@ -1,12 +1,55 @@
 package com.modutaxi.api.domain.onboarding.controller;
 
+import com.modutaxi.api.common.exception.errorcode.OnboardingErrorCode;
+import com.modutaxi.api.domain.onboarding.dto.OnboardingRequestDto.OnboardingRequest;
+import com.modutaxi.api.domain.onboarding.service.RegisterOnboardingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/onboardings")
+@Tag(name = "설문 조사", description = "설문 조사 API")
 public class RegisterOnboardingController {
+
+    private final RegisterOnboardingService registerOnboardingService;
+
+    /**
+     * [POST] 설문 조사
+     */
+    @Operation(summary = "설문 조사", description = """
+            성공하면 body에 200 내려가요!
+            현재 존재하는 설문조사 번호는 1~2번입니다.
+            etc가 true일 때는 etcContent에 기타 사유를 넣어주시고, etc가 false라면 etcContent에 null이 아닌 블랭크를 담아 전송해주세요.""")
+    @PostMapping("")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "설문 조사 성공"),
+            @ApiResponse(responseCode = "400", description = "설문 조사 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = OnboardingErrorCode.class), examples = {
+                    @ExampleObject(name = "ONBOARDING_001", value = """
+                            {
+                                "code": "ONBOARDING_001",
+                                "message": "존재하지 않는 설문조사 ID 입니다.",
+                                "timeStamp": "2024-04-04T02:48:31.646102"
+                            }
+                            """, description = "일치하는 ID를 가진 설문조사가 존재하지 않습니다."),
+            })),
+    })
+    public ResponseEntity<Integer> register(
+            @Valid @RequestBody OnboardingRequest onboardingRequest) {
+        registerOnboardingService.registerOnboarding(onboardingRequest);
+        return ResponseEntity.ok(200);
+    }
 
 }

--- a/src/main/java/com/modutaxi/api/domain/onboarding/dto/OnboardingRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/dto/OnboardingRequestDto.java
@@ -1,5 +1,30 @@
 package com.modutaxi.api.domain.onboarding.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class OnboardingRequestDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class OnboardingRequest {
+        @Schema(example = "1", description = "설문조사 ID (현재 존재하는 설문조사 ID는 1~2입니다.)")
+        private int questionId;
+
+        @Schema(example = "true", description = "1번 응답을 체크했다면 true, 체크하지 않았다면 false")
+        private boolean answer1;
+        @Schema(example = "true", description = "2번 응답을 체크했다면 true, 체크하지 않았다면 false")
+        private boolean answer2;
+        @Schema(example = "true", description = "3번 응답을 체크했다면 true, 체크하지 않았다면 false")
+        private boolean answer3;
+
+        @Schema(example = "true", description = "기타에 체크했다면 true, 체크하지 않았다면 false")
+        private boolean etc;
+        @Schema(example = "어쩌구 저쩌구해서 이러쿵 저러쿵 했습니다.", description = "etc가 true일 때는 기타 사유를 넣어주시고, etc가 false라면 null이 아닌 블랭크로 전송해주세요.")
+        private String etcContent;
+    }
 
 }

--- a/src/main/java/com/modutaxi/api/domain/onboarding/entity/Onboarding.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/entity/Onboarding.java
@@ -5,11 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @AllArgsConstructor
@@ -17,9 +19,40 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 public class Onboarding extends BaseTime {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
+    private int questionId;
+
+    @Builder.Default
+    @ColumnDefault("0")
+    private int etcCount = 0;
+    @Builder.Default
+    @ColumnDefault("0")
+    private int answer1Count = 0;
+    @Builder.Default
+    @ColumnDefault("0")
+    private int answer2Count = 0;
+    @Builder.Default
+    @ColumnDefault("0")
+    private int answer3Count = 0;
+
+    @Builder.Default
+    @ColumnDefault("0")
+    private int respondentCount = 0;    // 응답자의 총 수
+
+    public void upAnswerCount(boolean etc, boolean answer1, boolean answer2, boolean answer3) {
+        if(etc) this.etcCount++;
+        if(answer1) this.answer1Count++;
+        if(answer2) this.answer2Count++;
+        if(answer3) this.answer3Count++;
+    }
+
+    public void upRespondentCount() {
+        this.respondentCount++;
+    }
 
 }

--- a/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingAnswerList.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingAnswerList.java
@@ -1,0 +1,24 @@
+package com.modutaxi.api.domain.onboarding.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OnboardingAnswerList {
+
+    ETC(0,0, "기타"),
+
+    ANSWER1(1, 1,"에브리타임을 통해 알게 되었어요!"),
+    ANSWER2(1, 2, "지인 추천을 통해 알게 되었어요!"),
+    ANSWER3(1, 3, "직접 검색해서 알게 되었어요!"),
+
+    ANSWER4(2, 1, "지각할 것 같을 때"),
+    ANSWER5(2, 2, "버스 줄이 너무 길 때"),
+    ANSWER6(2, 3, "편하게 가고 싶을 때")
+    ;
+
+    private final int questionId;
+    private final int answerId;
+    private final String content;
+}

--- a/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingEtc.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingEtc.java
@@ -1,0 +1,27 @@
+package com.modutaxi.api.domain.onboarding.entity;
+
+import com.modutaxi.api.common.entity.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Builder
+public class OnboardingEtc extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private int questionId;
+
+    @NotNull
+    private String content;
+}

--- a/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingQuestionList.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/entity/OnboardingQuestionList.java
@@ -1,0 +1,17 @@
+package com.modutaxi.api.domain.onboarding.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OnboardingQuestionList {
+
+    QUESTION1(1, "모두의 택시, 어떻게 이용하게 되셨나요?", 3),
+    QUESTION2(2, "택시를 가장 타고 싶었던 순간이 있으신가요?", 3),
+    ;
+
+    private final int questionId;
+    private final String content;
+    private final int numberOfAnswer;
+}

--- a/src/main/java/com/modutaxi/api/domain/onboarding/mapper/OnboardingMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/mapper/OnboardingMapper.java
@@ -1,0 +1,22 @@
+package com.modutaxi.api.domain.onboarding.mapper;
+
+import com.modutaxi.api.domain.onboarding.entity.Onboarding;
+import com.modutaxi.api.domain.onboarding.entity.OnboardingEtc;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OnboardingMapper {
+
+    public Onboarding toEntity(int questionId) {
+        return Onboarding.builder()
+                .questionId(questionId)
+                .build();
+    }
+
+    public OnboardingEtc toEntity(int questionId, String content) {
+        return OnboardingEtc.builder()
+                .questionId(questionId)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/onboarding/repository/OnboardingEtcRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/repository/OnboardingEtcRepository.java
@@ -1,0 +1,7 @@
+package com.modutaxi.api.domain.onboarding.repository;
+
+import com.modutaxi.api.domain.onboarding.entity.OnboardingEtc;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OnboardingEtcRepository extends JpaRepository<OnboardingEtc, Long> {
+}

--- a/src/main/java/com/modutaxi/api/domain/onboarding/repository/OnboardingRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/repository/OnboardingRepository.java
@@ -3,6 +3,10 @@ package com.modutaxi.api.domain.onboarding.repository;
 import com.modutaxi.api.domain.onboarding.entity.Onboarding;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OnboardingRepository extends JpaRepository<Onboarding, Long> {
+
+    Optional<Onboarding> findByQuestionId(int questionId);
 
 }

--- a/src/main/java/com/modutaxi/api/domain/onboarding/service/RegisterOnboardingService.java
+++ b/src/main/java/com/modutaxi/api/domain/onboarding/service/RegisterOnboardingService.java
@@ -1,10 +1,49 @@
 package com.modutaxi.api.domain.onboarding.service;
 
+import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.exception.errorcode.OnboardingErrorCode;
+import com.modutaxi.api.domain.onboarding.dto.OnboardingRequestDto.OnboardingRequest;
+import com.modutaxi.api.domain.onboarding.entity.Onboarding;
+import com.modutaxi.api.domain.onboarding.mapper.OnboardingMapper;
+import com.modutaxi.api.domain.onboarding.repository.OnboardingEtcRepository;
+import com.modutaxi.api.domain.onboarding.repository.OnboardingRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class RegisterOnboardingService {
 
+    private final OnboardingRepository onboardingRepository;
+    private final OnboardingEtcRepository onboardingEtcRepository;
+    private final OnboardingMapper onboardingMapper;
+
+    public void registerOnboarding(OnboardingRequest onboardingRequest) {
+        Onboarding onboarding = onboardingRepository.findByQuestionId(onboardingRequest.getQuestionId())
+                .orElseThrow(() -> new BaseException(OnboardingErrorCode.EMPTY_ONBOARDING));
+
+        // 대답이 true 면 카운트 ++, 확장 시 여기 부분만 수정하면 됩니다!
+        onboarding.upAnswerCount(
+                onboardingRequest.isEtc(),
+                onboardingRequest.isAnswer1(),
+                onboardingRequest.isAnswer2(),
+                onboardingRequest.isAnswer3()
+        );
+
+        // 응답자 수 ++
+        onboarding.upRespondentCount();
+
+        // 기타에 응답했다면 OnboardingEtc register
+        if(onboardingRequest.isEtc()) {
+            registerOnboardingEtc(onboarding.getQuestionId(), onboardingRequest.getEtcContent());
+        }
+    }
+
+    public void registerOnboardingEtc(int questionId, String content) {
+        onboardingEtcRepository.save(
+                onboardingMapper.toEntity(questionId, content)
+        );
+    }
 }


### PR DESCRIPTION
## 요약 🎀

- 설문조사 API 구현
- 서버 최초 실행 시 설문조사 질문이 자동으로 DB에 생성되도록 구현

## 상세 내용 🌈

- 설문조사 Entity는 총 2개를 사용했습니다.
  - Onboarding
    - questionId(질문 Id), answerCount(답변 카운터), respondentCount(응답자 수) 등을 가지고 있는 Entrity
    - 1개의 행이 1개의 질문을 의미하며, 답변 수를 카운트 하기 위해 사용됩니다.
    - 현재 answerCount를 3개 가지고 있는데, 답변의 개수가 1개 늘어날 때마다 Entity(`Onboarding`), Dto(`OnboardingRequest`), 함수(`RegisterOnboardingService.registerOnboarding`)에 각각 1~2줄 씩만 추가해주면 됩니다. 사실 답변을 List 형식으로 받는게 가장 확장성이 좋긴 한데, 다소 복잡해지기도 하고 그정도까지는 필요없을 것 같아서 이렇게 구현했습니다.
    
    ![온보딩 DB](https://github.com/MODU-TAXI/server-api/assets/71329329/f26fa051-e5ba-4343-b4f4-84dd8bf69f52)

  - OnboardingEtc
    - questionId(질문 Id), content(기타 응답 사유)를 가지고 있는 Entity
    - 사용자가 기타에 체크했을 경우에만 register되며, 자세한 응답 사유를 저장하기 위해 사용됩니다.
- 서버 최초 실행 시 설문조사 질문이 자동으로 DB에 생성되도록 구현
  - 서버가 최초로 실행 될 때 DB에 질문 별로 행이 존재해야 카운팅이 되는데, 매번 서버를 킬 때마다 수작업으로 할 순 없으므로 `ApplicationListener<ContextRefreshedEvent>`를 `implements` 한 `InitialApplicationListener` 를 구현했습니다.
  - Spring 컨텍스트의 초기화가 완료된 후, 즉 모든 Bean의 초기화가 완료된 후에 1회만 실행됩니다.
  - 질문 1개 당 아래와 같이 작동돼요! 만약, 이미 질문이 DB에 존재한다면 select문까지만 작동하겠죠!?
   ![온보딩 캡쳐 1](https://github.com/MODU-TAXI/server-api/assets/71329329/b9e6db83-e5f8-4116-ae6c-3b8c9f4b7a30)


## 질문 및 이외 사항 🚩

- 참고: https://sgc109.github.io/2020/07/09/spring-running-startup-logic/#Spring-Boot-%EC%9D%98-ApplicationRunner

## 리뷰어에게 ✨

- enum class는 나중에 설문 조사 결과 확인하는 API 만들려고 미리 작성해놨습니다!
- 궁금한 점 있으시다면 리뷰 달아주세요!
