### PR TITLE
[MS-102] 테스트용 서버 설정

### DIFF
--- a/.github/workflows/CD-TestServer.yml
+++ b/.github/workflows/CD-TestServer.yml
@@ -65,7 +65,7 @@ jobs:
           username: ${{ secrets.TEST_SERVER_SSH_USERNAME }}
           key: ${{ secrets.TEST_SERVER_SSH_PRIVATE_KEY }}
           source: "docker-compose.testserver.yml, config/dockerEnv/dev.env"
-          target: /home/ec2-user
+          target: /home/ubuntu
 
       - name: Deploy
         uses: appleboy/ssh-action@master
@@ -75,7 +75,7 @@ jobs:
           username: ${{ secrets.TEST_SERVER_SSH_USERNAME }}
           key: ${{ secrets.TEST_SERVER_SSH_PRIVATE_KEY }}
           script: |
-            cd /home/ec2-user 
+            cd /home/ubuntu
             sudo docker login ${{ env.REGISTRY }} -u ${{ env.GITHUB_ACTOR }} -p ${{ secrets.TOKEN_GITHUB }}
             sudo docker container stop spring
             sudo docker container rm spring

--- a/.github/workflows/CD-TestServer.yml
+++ b/.github/workflows/CD-TestServer.yml
@@ -1,0 +1,84 @@
+name: Test Server Deploy
+
+on:
+  push:
+    tags:
+      - 't-**'
+
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+  GITHUB_ACTOR: ${{ github.actor }}
+
+jobs:
+  testServerDeploy:
+    name: Deploy to TestServer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOKEN_GITHUB }}
+          submodules: recursive
+
+      - name: Git Submodule Update
+        run: |
+          git submodule update --remote --recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.GITHUB_ACTOR }}
+          password: ${{ secrets.TOKEN_GITHUB }}
+
+      - name: lowercase the image tag & repository
+        run: |
+          echo "REPOSITORY=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+
+      - name: Get Version
+        run: echo "VERSION=$(git tag --points-at)" >> ${GITHUB_ENV}
+
+      - name: Set Spring Image Environment Variable
+        run: |
+          echo "SPRING_IMAGE=${{ env.REGISTRY }}/${{ env.REPOSITORY }}-testserver:${{ env.VERSION }}" >> ${GITHUB_ENV}
+
+      - name: Write Version
+        run: |
+          echo -e "\nserver-version: ${{ env.VERSION }}" >> config/application-testserver.yml
+
+      - name: Build Image
+        run: docker build --no-cache -t ${{ env.SPRING_IMAGE }} -f Dockerfile-dev .
+
+      - name: Push
+        run: docker push ${{ env.SPRING_IMAGE }}
+
+      - name: Write Docker Image Tag Information to .env File
+        run: |
+          echo -e "\nSPRING_IMAGE=${{ env.SPRING_IMAGE }}" >> config/env/dev.env
+
+      - name: Copy docker-compose.yml
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.TEST_SERVER_SSH_HOST }}
+          port: ${{ secrets.TEST_SERVER_SSH_PORT }}
+          username: ${{ secrets.TEST_SERVER_SSH_USERNAME }}
+          key: ${{ secrets.TEST_SERVER_SSH_PRIVATE_KEY }}
+          source: "docker-compose.testserver.yml, config/env/dev.env"
+          target: /home/ec2-user
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.TEST_SERVER_SSH_HOST }}
+          port: ${{ secrets.TEST_SERVER_SSH_PORT }}
+          username: ${{ secrets.TEST_SERVER_SSH_USERNAME }}
+          key: ${{ secrets.TEST_SERVER_SSH_PRIVATE_KEY }}
+          script: |
+            cd /home/ec2-user 
+            sudo docker login ${{ env.REGISTRY }} -u ${{ env.GITHUB_ACTOR }} -p ${{ secrets.TOKEN_GITHUB }}
+            sudo docker container stop spring
+            sudo docker container rm spring
+            sudo docker image rm ${{ env.SPRING_IMAGE }}
+            sudo docker-compose --env-file=config/env/dev.env -f docker-compose.testserver.yml -p backend up -d
+            sudo docker image prune -af

--- a/.github/workflows/CD-TestServer.yml
+++ b/.github/workflows/CD-TestServer.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Write Docker Image Tag Information to .env File
         run: |
-          echo -e "\nSPRING_IMAGE=${{ env.SPRING_IMAGE }}" >> config/env/dev.env
+          echo -e "\nSPRING_IMAGE=${{ env.SPRING_IMAGE }}" >> config/dockerEnv/dev.env
 
       - name: Copy docker-compose.yml
         uses: appleboy/scp-action@master
@@ -64,7 +64,7 @@ jobs:
           port: ${{ secrets.TEST_SERVER_SSH_PORT }}
           username: ${{ secrets.TEST_SERVER_SSH_USERNAME }}
           key: ${{ secrets.TEST_SERVER_SSH_PRIVATE_KEY }}
-          source: "docker-compose.testserver.yml, config/env/dev.env"
+          source: "docker-compose.testserver.yml, config/dockerEnv/dev.env"
           target: /home/ec2-user
 
       - name: Deploy
@@ -80,5 +80,5 @@ jobs:
             sudo docker container stop spring
             sudo docker container rm spring
             sudo docker image rm ${{ env.SPRING_IMAGE }}
-            sudo docker-compose --env-file=config/env/dev.env -f docker-compose.testserver.yml -p backend up -d
+            sudo docker-compose --env-file=config/dockerEnv/dev.env -f docker-compose.testserver.yml -p backend up -d
             sudo docker image prune -af

--- a/docker-compose.testserver.yml
+++ b/docker-compose.testserver.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  spring:
+    container_name: spring
+    image: ${SPRING_IMAGE}
+    environment:
+      - SPRING_PROFILES_ACTIVE=testserver
+    ports:
+      - ${SPRING_OUTER_PORT}:${SPRING_INNER_PORT}
+    networks:
+      modutaxi_network:
+        ipv4_address: ${NETWORK_SPRING_IP}
+    depends_on:
+      - mongo
+  mongo:
+    container_name: mongo
+    image: mongo:latest
+    ports:
+      - ${MONGO_OUTER_PORT}:${MONGO_INNER_PORT}
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
+      - MONGO_INITDB_DATABASE=${MONGO_INITDB_DATABASE}
+    volumes:
+      - ${MONGO_VOLUME}:/data/db
+    networks:
+      modutaxi_network:
+        ipv4_address: ${NETWORK_MONGO_IP}
+networks:
+  modutaxi_network:
+    driver: bridge
+    internal: false
+    ipam:
+      driver: default
+      config:
+        - subnet: ${NETWORK_SUBNET}
+          ip_range: ${NETWORK_IP_RANGE}
+          gateway: ${NETWORK_GATEWAY}

--- a/src/main/java/com/modutaxi/api/common/config/SwaggerConfig.java
+++ b/src/main/java/com/modutaxi/api/common/config/SwaggerConfig.java
@@ -9,42 +9,46 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        servers = {@Server(url = "${spring.swagger.domain}")},
-        info = @Info(title = "Modu's Taxi Server's API",
-                description = "모두의 택시 서버 API 명세서",
-                version = "v1"))
+    servers = {@Server(url = "${spring.swagger.domain}")},
+    info = @Info(title = "Modu's Taxi Server's API",
+        description = "모두의 택시 서버 API 명세서",
+        version = "${server-version}"))
 @Configuration
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-    @Bean
-    public GroupedOpenApi OpenApi() {
-        String[] paths = {"/**"};
-        return GroupedOpenApi.builder()
-                .group("모두의 택시 API v1")
-                .pathsToMatch(paths)
-                .build();
-    }
+  @Value("${server-version}")
+  private String version;
 
-    @Bean
-    public OpenAPI openAPI() {
-        // SecuritySecheme명
-        String jwtSchemeName = "jwtAuth";
-        // API 요청헤더에 인증정보 포함
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
-        // SecuritySchemes 등록
-        Components components = new Components()
-                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
-                        .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP)
-                        .scheme("Bearer"));
+  @Bean
+  public GroupedOpenApi OpenApi() {
+    String[] paths = {"/**"};
+    return GroupedOpenApi.builder()
+        .group(String.format("모두의 택시 API %s", version))
+        .pathsToMatch(paths)
+        .build();
+  }
 
-        return new OpenAPI()
-                .addSecurityItem(securityRequirement)
-                .components(components);
-    }
+  @Bean
+  public OpenAPI openAPI() {
+    // SecuritySecheme명
+    String jwtSchemeName = "jwtAuth";
+    // API 요청헤더에 인증정보 포함
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+    // SecuritySchemes 등록
+    Components components = new Components()
+        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+            .name(jwtSchemeName)
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("Bearer"));
+
+    return new OpenAPI()
+        .addSecurityItem(securityRequirement)
+        .components(components);
+  }
 }

--- a/src/main/java/com/modutaxi/api/common/config/redis/redisExample/RedisExampleController.java
+++ b/src/main/java/com/modutaxi/api/common/config/redis/redisExample/RedisExampleController.java
@@ -1,5 +1,6 @@
 package com.modutaxi.api.common.config.redis.redisExample;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/redis")
 public class RedisExampleController {
     private final RedisExampleRepository redisExampleRepository;
+    @Hidden
     @GetMapping("/save/{key}/{value}")
     public String save(@PathVariable("key") String key, @PathVariable("value") String value) {
         RedisExampleDomain redisExampleDomain = new RedisExampleDomain();
@@ -20,6 +22,7 @@ public class RedisExampleController {
         return res;
     }
 
+    @Hidden
     @GetMapping("/get/{key}")
     public RedisExampleDomain get(@PathVariable("key") String key) {
         RedisExampleDomain res = redisExampleRepository.findById(key);

--- a/src/main/java/com/modutaxi/api/common/s3/S3Controller.java
+++ b/src/main/java/com/modutaxi/api/common/s3/S3Controller.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.common.s3;
 
 import com.modutaxi.api.common.s3.dto.S3Result;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,12 +20,14 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
+    @Hidden
     @PostMapping
     public ResponseEntity<S3Result> uploadFile(@RequestPart(value = "file") MultipartFile file) {
         S3Result result = s3Service.uploadFile(file);
         return ResponseEntity.ok(result);
     }
 
+    @Hidden
     @DeleteMapping
     public ResponseEntity<String> deleteFile(@RequestParam String fileName) {
         s3Service.deleteFile(fileName);


### PR DESCRIPTION
## 요약 🎀
- 테스트용 서버 배포 파이프라인 설정

## 상세 내용 🌈
- 15GB, t2-namo 사양의 EC2를 새로 대여하여 테스트용 서버를 구축하였습니다.
- 테스트용 서버 배포 사용법
  - `t-{기능이름}-{버전}` 과 같이 깃 태그를 생성 후 깃헙에 푸시하게되면 배포 파이프라인이 작동합니다.
  - 한번에 하나의 서버 애플리케이션만 운용 가능합니다.
  - testserver 프로파일의 설정값을 이용합니다.
- 스웨거의 버전을 더 명시적으로 변경하였습니다.
  - 테스트용 서버에 어떤 기능을 위해 배포가 되어있는지 명시적입니다.
    <img width="619" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/25c922bd-a6b8-40cd-bedb-16dec0be6ed6">
  - local과 dev 프로파일 또한 변경되었습니다.
    <img width="472" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/84d108bd-509d-49e2-9e41-26d690626f7c">
- 프로젝트 기능구현과 관련없는 API 엔드포인트를 스웨거에서 숨김처리 하였습니다.
  - s3 예시코드
  - redis 예시코드