### PR TITLE
[MS-107] 전화 인증 시 동일한 조건으로 재전송 시 무조건 에러를 반환 하던 오류 수정

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/sms/service/SmsServiceCoolSmsImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/sms/service/SmsServiceCoolSmsImpl.java
@@ -103,9 +103,8 @@ public class SmsServiceCoolSmsImpl implements SmsService {
         if (status.equals("PENDING")) {
             throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_SENDING);
         } else if (status.equals("SENDING")) {
-            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_ALREADY_SENT);
+            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_SENDING);
         } else if (status.equals("COMPLETE")) {
-            throw new BaseException(SmsErrorCode.CERTIFICATION_CODE_ALREADY_SENT);
         } else if (status.equals("FAILED")) {
             log.warn("[COOL SMS] 메세지 발송에 실패하여 재시도 합니다.");
         }


### PR DESCRIPTION
## 요약 🎀
- 전화 인증 시 동일한 조건으로 재전송 시 무조건 에러를 반환 하던 오류 수정

## 상세 내용 🌈
- 전화 인증 시 동일한 조건으로 재전송 시 무조건 에러를 반환 하던 오류 수정
  - 전화 인증 후 동일한 조건으로 재전송 시 전송 중이거나 전송이 완료된 경우 '이미 전송되었습니다' 라는 에러를 발생시키던 오류 수정