### PR TITLE
[MS-106] 거점 관련 기능 수정

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
@@ -1,8 +1,10 @@
 package com.modutaxi.api.domain.spot.controller;
 
 
+import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.SpotError;
+import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.spot.dto.SpotRequestDto.GetAreaSpotRequest;
 import com.modutaxi.api.domain.spot.dto.SpotResponseDto.GetSpotResponses;
 import com.modutaxi.api.domain.spot.dto.SpotResponseDto.GetSpotWithDistanceResponse;
@@ -54,6 +56,7 @@ public class GetSpotController {
             })),
     })
     public ResponseEntity<GetSpotWithDistanceResponse> getSpot(
+            @CurrentMember Member member,
             @Parameter(description = "거점 id")
             @PathVariable(value = "id") Long id,
             @Parameter(description = "경도")
@@ -64,7 +67,7 @@ public class GetSpotController {
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate = new Coordinate(longitude, latitude);
         Point point = geometryFactory.createPoint(coordinate);
-        return ResponseEntity.ok(getSpotService.getSpot(id, point));
+        return ResponseEntity.ok(getSpotService.getSpot(member, id, point));
     }
 
     @Hidden

--- a/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
@@ -149,16 +149,26 @@ public class GetSpotController {
             @ApiResponse(responseCode = "200", description = "거점 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = GetSpotWithDistanceResponses.class))),
     })
     public ResponseEntity<GetSpotWithDistanceResponses> getNearSpots(
-            @Parameter(description = "조회할 개수<br>기본값: 3개")
-            @RequestParam(value = "count", defaultValue = "3", required = false) Long count,
-            @Parameter(description = "경도")
-            @RequestParam(value = "longitude") Float longitude,
-            @Parameter(description = "위도")
-            @RequestParam(value = "latitude") Float latitude
+            @CurrentMember Member member,
+            @Parameter(description = "조회할 page")
+            @RequestParam(value = "page") int page,
+            @Parameter(description = "조회할 page 단위")
+            @RequestParam(value = "size") int size,
+            @Parameter(description = "현재 경도")
+            @RequestParam(value = "currentLongitude") Float currentLongitude,
+            @Parameter(description = "현재 위도")
+            @RequestParam(value = "currentLatitude") Float currentLatitude,
+            @Parameter(description = "검색 기준 경도")
+            @RequestParam(value = "searchLongitude") Float searchLongitude,
+            @Parameter(description = "검색 기준 위도")
+            @RequestParam(value = "searchLatitude") Float searchLatitude
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
-        Coordinate coordinate = new Coordinate(longitude, latitude);
-        Point point = geometryFactory.createPoint(coordinate);
-        return ResponseEntity.ok(getSpotService.getNearSpots(point, count));
+        Coordinate currentCoordinate = new Coordinate(currentLongitude, currentLatitude);
+        Point currentPoint = geometryFactory.createPoint(currentCoordinate);
+
+        Coordinate searchCoordinate = new Coordinate(searchLongitude, searchLatitude);
+        Point searchPoint = geometryFactory.createPoint(searchCoordinate);
+        return ResponseEntity.ok(getSpotService.getNearSpots(member, currentPoint, searchPoint, page, size));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
@@ -1,10 +1,12 @@
 package com.modutaxi.api.domain.spot.repository;
 
+import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.spot.dao.SpotMysqlResponse.SearchWithRadiusResponseInterface;
 import com.modutaxi.api.domain.spot.dao.SpotMysqlResponse.SpotWithDistanceResponseInterface;
 import com.modutaxi.api.domain.spot.entity.Spot;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,11 +18,11 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     Boolean existsByNameEquals(String name);
 
     @Query("SELECT " +
-            "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint, ST_DISTANCE_SPHERE(:point, s.spotPoint) AS distance, (l.id IS NOT NULL) AS liked " +
+            "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint, ST_DISTANCE_SPHERE(:point, s.spotPoint) AS distance, (CASE WHEN l.member = :member THEN true ELSE false END) AS liked " +
             "FROM Spot s LEFT JOIN LikedSpot l ON (s.id = l.spot.id) " +
             "WHERE " +
             "s.id = :id")
-    Optional<SpotWithDistanceResponseInterface> findByIdWithDistance(@Param("id") Long id, @Param("point") Point point);
+    Optional<SpotWithDistanceResponseInterface> findByIdWithDistance(@Param("member") Member member, @Param("id") Long id, @Param("point") Point point);
 
     @Query("SELECT " +
             "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint " +

--- a/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
@@ -42,11 +42,10 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     List<SearchWithRadiusResponseInterface> findNearSpotsInRadius(@Param("point") Point point, @Param("radius") Long radius);
 
     @Query("SELECT " +
-            "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint, ST_DISTANCE_SPHERE(:point, s.spotPoint) AS distance, (l.id IS NOT NULL) AS liked " +
+            "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint, ST_DISTANCE_SPHERE(:currentPoint, s.spotPoint) AS distance, (CASE WHEN l.member = :member THEN true ELSE false END) AS liked " +
             "FROM Spot s LEFT JOIN LikedSpot l ON (s.id = l.spot.id) " +
             "ORDER BY " +
-            "ST_DISTANCE_SPHERE(:point, s.spotPoint) " +
-            "LIMIT :num"
+            "ST_DISTANCE_SPHERE(:searchPoint, s.spotPoint) "
     )
-    List<SpotWithDistanceResponseInterface> findNearSpots(@Param("point") Point point, @Param("num") Long count);
+    List<SpotWithDistanceResponseInterface> findNearSpots(@Param("member") Member member, @Param("currentPoint") Point currentPoint, @Param("searchPoint") Point searchPoint, Pageable pageable);
 }

--- a/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
@@ -49,8 +49,9 @@ public class GetSpotService {
         return new SearchWithRadiusResponses(spotList);
     }
 
-    public GetSpotWithDistanceResponses getNearSpots(Point point, Long count) {
-        List<SpotWithDistanceResponseInterface> spots = spotRepository.findNearSpots(point, count);
+    public GetSpotWithDistanceResponses getNearSpots(Member member, Point currentPoint, Point searchPoint, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        List<SpotWithDistanceResponseInterface> spots = spotRepository.findNearSpots(member, currentPoint, searchPoint, pageable);
         List<GetSpotWithDistanceResponse> spotList = spots.stream().map(SpotResponseMapper::toSpotWithDistanceResponse).toList();
         return new GetSpotWithDistanceResponses(spotList);
     }

--- a/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.domain.spot.service;
 
 import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.spot.dao.SpotMysqlResponse.SearchWithRadiusResponseInterface;
 import com.modutaxi.api.domain.spot.dao.SpotMysqlResponse.SpotWithDistanceResponseInterface;
 import com.modutaxi.api.domain.spot.dto.SpotResponseDto.*;
@@ -10,6 +11,8 @@ import com.modutaxi.api.domain.spot.repository.SpotRepository;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -27,8 +30,8 @@ public class GetSpotService {
         );
     }
 
-    public GetSpotWithDistanceResponse getSpot(Long id, Point point) {
-        SpotWithDistanceResponseInterface spot = spotRepository.findByIdWithDistance(id, point).orElseThrow(
+    public GetSpotWithDistanceResponse getSpot(Member member, Long id, Point point) {
+        SpotWithDistanceResponseInterface spot = spotRepository.findByIdWithDistance(member, id, point).orElseThrow(
                 () -> new BaseException(SPOT_ID_NOT_FOUND)
         );
         return SpotResponseMapper.toSpotWithDistanceResponse(spot);


### PR DESCRIPTION
## 요약 🎀
- 거점 관련 기능 수정

## 상세 내용 🌈
- 특정 거점 조회, 거점 리스트 조회 시 본인이 거점을 찜하지 않았더라도 누구든 찜 헀다면 찜으로 보이던 오류 수정
- 거점 리스트 조회 시 검색 위치로부터의 거리 순으로 정렬, 사용자의 위치로부터의 거리를 반환 하도록 수정

## 질문 및 이외 사항 🚩
- 거점 리스트 조회
  <img width="613" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/7aae2ea1-d72c-4f17-86e8-47fdee7deeef">

## 리뷰어에게 ✨
- 지난번 회의에서 얘기한 구글 스타일을 적용할 만큼의 수정은 아니었다고 여겨 스타일 가이드는 수정하지 않았습니다.
