### PR TITLE
[MS-49] 로그아웃 API

### DIFF
--- a/src/main/java/com/modutaxi/api/common/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/modutaxi/api/common/auth/jwt/JwtAuthenticationFilter.java
@@ -36,9 +36,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
             authentication = jwtTokenProvider.getRefreshAuthentication(refreshToken); // authentication 세팅
         }
         // 헤더에 aceessToken을 보냈을 경우
-        else if(token != null) {
+        else if (token != null) {
             jwtTokenProvider.validateAccessToken(token); // 유효성 검사
             authentication = jwtTokenProvider.getAccessAuthentication(token); // authentication 세팅
+            // 로그아웃 요청
+            if (((HttpServletRequest) request).getRequestURI().equals("/api/members/logout")) {
+                jwtTokenProvider.logout(token);
+            }
         }
         SecurityContextHolder.getContext().setAuthentication(authentication);
         chain.doFilter(request, response);

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/AuthErrorCode.java
@@ -15,8 +15,8 @@ public enum AuthErrorCode implements ErrorCode {
     UNSUPPORTED_JWT("AUTH_004", "지원하지 않는 JWT입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_SNS_ID_KEY("AUTH_005", "유효하지 않은 snsId key입니다.", HttpStatus.BAD_REQUEST),
     INVALID_ACCESS_TOKEN("AUTH_006", "유효하지 않은 ACCESS TOKEN입니다.", HttpStatus.BAD_REQUEST),
-    FAILED_SOCIAL_LOGIN("AUTH_007", "소셜 로그인에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
-    ;
+    FAILED_SOCIAL_LOGIN("AUTH_007", "소셜 로그인에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    LOGOUT_JWT("AUTH_008", "로그아웃 처리된 JWT입니다.", HttpStatus.UNAUTHORIZED);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
@@ -63,4 +63,14 @@ public class RegisterMemberController {
         return ResponseEntity.ok(registerMemberService.checkMembership(
                 type, loginRequest.getAccessToken()));
     }
+
+    /**
+     * [POST] 로그아웃
+     * /logout
+     */
+    @Operation(summary = "로그아웃", description = "헤더에 반드시 Authorization 으로 accessToken 값을 넣어주세요!")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -8,7 +8,7 @@ import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmSmsCertificati
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendMailCertificationRequest;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.SendSmsCertificationRequest;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
+import com.modutaxi.api.domain.member.dto.MemberResponseDto.RefreshTokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.service.UpdateMemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,9 +40,9 @@ public class UpdateMemberController {
                     "key: refreshToken, value: ${refreshToken}."
     )
     @PatchMapping("/refresh")
-    public ResponseEntity<TokenResponse> refreshLogin(
+    public ResponseEntity<RefreshTokenResponse> refreshLogin(
             @CurrentMember Member member) {
-        return new ResponseEntity<>(updateMemberService.refreshAccessToken(member.getId()),
+        return new ResponseEntity<>(updateMemberService.refreshAccessToken(member),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -1,7 +1,9 @@
 package com.modutaxi.api.domain.member.dto;
 
+import com.modutaxi.api.domain.member.entity.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public class MemberResponseDto {
@@ -11,6 +13,14 @@ public class MemberResponseDto {
     public static class TokenResponse {
         private String accessToken;
         private String refreshToken;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RefreshTokenResponse {
+        private TokenResponse tokenResponse;
+        private MemberInfoResponse memberInfoResponse;
     }
 
     @Getter
@@ -25,5 +35,17 @@ public class MemberResponseDto {
     public static class MembershipResponse {
         private boolean existent;
         private String key;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class MemberInfoResponse {
+        private Long id;
+        private String name;
+        private Gender gender;
+        private String phoneNumber;
+        private String email;
+        private double score;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -33,9 +33,6 @@ public class Member extends BaseTime {
 
     @NotNull
     @Builder.Default
-    private String refreshToken = "";
-    @NotNull
-    @Builder.Default
     private double score = 0.0; // 평점
 
     @NotNull
@@ -49,10 +46,6 @@ public class Member extends BaseTime {
     @NotNull
     @Builder.Default
     private boolean status = true;
-
-    public void changeRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
 
     public void certificateEmail(String email) {
         this.role = Role.ROLE_MEMBER;

--- a/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
@@ -1,5 +1,6 @@
 package com.modutaxi.api.domain.member.mapper;
 
+import com.modutaxi.api.domain.member.dto.MemberResponseDto.MemberInfoResponse;
 import com.modutaxi.api.domain.member.entity.Gender;
 import com.modutaxi.api.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
@@ -7,12 +8,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberMapper {
 
-    public Member toEntity(String snsId, String name, Gender gender, String phoneNumber) {
+    public static Member toEntity(String snsId, String name, Gender gender, String phoneNumber) {
         return Member.builder()
                 .snsId(snsId)
                 .name(name)
                 .gender(gender)
                 .phoneNumber(phoneNumber)
+                .build();
+    }
+
+    public static MemberInfoResponse toDto(Member member) {
+        return MemberInfoResponse.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .gender(member.getGender())
+                .phoneNumber(member.getPhoneNumber())
+                .email(member.getEmail())
+                .score(member.getScore())
                 .build();
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisATKRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisATKRepository.java
@@ -1,0 +1,8 @@
+package com.modutaxi.api.domain.member.repository;
+
+public interface RedisATKRepository {
+    void save(String accessToken, Long duration);
+
+    boolean existsById(String accessToken);
+
+}

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisATKRepositoryImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisATKRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.modutaxi.api.domain.member.repository;
+
+import com.modutaxi.api.common.config.redis.BaseRedisRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisATKRepositoryImpl extends BaseRedisRepository implements Serializable, RedisATKRepository {
+
+    public static final String REASON = "LOGOUT";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private ValueOperations<String, String> valueOperations;
+
+    @PostConstruct
+    protected void init() {
+        classInstance = RedisRTKRepositoryImpl.class;
+        valueOperations = redisTemplate.opsForValue();
+    }
+
+    @Override
+    public void save(String accessToken, Long duration) {
+        String key = generateGlobalKey(accessToken);
+        valueOperations.set(key, REASON, duration, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean existsById(String accessToken) {
+        return (valueOperations.get(generateGlobalKey(accessToken)) != null);
+    }
+
+}

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisRTKRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisRTKRepository.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.domain.member.repository;
 
 public interface RedisRTKRepository {
-    Boolean save(String refreshToken, Long memberId);
-    String findAndDeleteById(String key);
+    void save(Long memberId, String refreshToken, Long duration);
+
+    String findAndDeleteById(String memberId);
 }

--- a/src/main/java/com/modutaxi/api/domain/member/repository/RedisRTKRepositoryImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/RedisRTKRepositoryImpl.java
@@ -13,10 +13,9 @@ import java.util.concurrent.TimeUnit;
 @Repository
 @RequiredArgsConstructor
 public class RedisRTKRepositoryImpl extends BaseRedisRepository implements Serializable, RedisRTKRepository {
+
     private final RedisTemplate<String, String> redisTemplate;
     private ValueOperations<String, String> valueOperations;
-
-    public static final int REFRESH_TOKEN_VALID_DAYS = 7;
 
     @PostConstruct
     protected void init() {
@@ -25,15 +24,13 @@ public class RedisRTKRepositoryImpl extends BaseRedisRepository implements Seria
     }
 
     @Override
-    public Boolean save(String refreshToken, Long memberId) {
-        String key = generateGlobalKey(refreshToken);
-        valueOperations.set(key, memberId.toString());
-        redisTemplate.expire(key, REFRESH_TOKEN_VALID_DAYS, TimeUnit.DAYS);
-        return true;
+    public void save(Long memberId, String refreshToken, Long duration) {
+        String key = generateGlobalKey(memberId.toString());
+        valueOperations.set(key, refreshToken, duration, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public String findAndDeleteById(String key) {
-        return valueOperations.getAndDelete(generateGlobalKey(key));
+    public String findAndDeleteById(String memberId) {
+        return valueOperations.getAndDelete(generateGlobalKey(memberId));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -6,9 +6,10 @@ import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.domain.mail.service.MailService;
 import com.modutaxi.api.domain.mail.service.MailUtil;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
-import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenResponse;
+import com.modutaxi.api.domain.member.dto.MemberResponseDto.RefreshTokenResponse;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.entity.Role;
+import com.modutaxi.api.domain.member.mapper.MemberMapper;
 import com.modutaxi.api.domain.member.repository.MemberRepository;
 import com.modutaxi.api.domain.sms.service.SmsService;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +28,11 @@ public class UpdateMemberService {
     private final MailUtil mailUtil;
     private final SmsService smsService;
 
-    public TokenResponse refreshAccessToken(Long memberId) {
-        return jwtTokenProvider.generateToken(memberId);
+    public RefreshTokenResponse refreshAccessToken(Member member) {
+        return new RefreshTokenResponse(
+                jwtTokenProvider.generateToken(member.getId()),
+                MemberMapper.toDto(member)
+        );
     }
 
     public CertificationResponse sendEmailCertificationMail(Long memberId, String receiver) {

--- a/src/test/java/com/modutaxi/api/domain/member/entity/MemberTest.java
+++ b/src/test/java/com/modutaxi/api/domain/member/entity/MemberTest.java
@@ -1,10 +1,9 @@
 package com.modutaxi.api.domain.member.entity;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MemberTest {
 
@@ -24,20 +23,4 @@ class MemberTest {
         assertEquals(member.getGender(), Gender.FEMALE);
     }
 
-    @Test
-    @DisplayName("refreshToken이 바뀌는지 테스트")
-    void changeRefreshToken() {
-        // given
-        Member member = Member.builder()
-                .snsId("123456")
-                .name("지수")
-                .gender(Gender.FEMALE)
-                .build();
-
-        // when
-        member.changeRefreshToken("new token");
-
-        // then
-        assertEquals(member.getRefreshToken(), "new token");
-    }
 }


### PR DESCRIPTION
## 요약 🎀

- 리프레쉬 토큰 레디스에 저장하는 방식 변경
- 로그아웃 API 구현

## 상세 내용 🌈

- 리프레쉬 토큰 레디스에 저장하는 방식 변경
  - 원래는 `RTK : memberId` 으로 저장되어 있었는데, `memberId : RTK` 로 key랑 value를 바꿨습니다.
  - 원래 방식의 문제는 반드시 프론트로부터 리프레쉬 토큰을 받아야만 레디스에서 삭제할 수 있다는 점이었어요. 이것 때문에 저번에 망고가 보내주신 문제가 생긴 거기도 하고요! (아래 사진 첨부) 새롭게 토큰을 발급 받는 경우에 기존에 있던 리프레쉬 토큰이 지워져야하는데 원래 방식에선 그게 안돼서 key-value 순서를 변경했습니다.
  - 망고 사건 (*레디스에 리프레쉬 토큰이 쌓인 것을 망고가 알려준 사건이다.)
    <img width="737" alt="ㅇㅇㅇ" src="https://github.com/MODU-TAXI/server-api/assets/71329329/722e3cc3-c78b-4657-b8d1-f94fe89632ef">
  - 이제는 `memberId`로 관리하기 때문에 새롭게 토큰을 발급받거나 로그아웃 처리 할 때에도 **1개의 member 당 1개의 리프레시 토큰**이 잘 지켜집니다!
- 로그아웃 API 구현 
  - 로그아웃 API를 호출한 `ATK`를 블랙리스트에 넣습니다! 아래처럼 `ATK : "LOGOUT"` 형태로 들어갑니다. 다른 이유로 블랙리스트에 올라간다면, `LOGOUT` 대신 다른 String이 들어가겠죠?!
  
![123](https://github.com/MODU-TAXI/server-api/assets/71329329/c5a3acef-35c5-46a0-b445-5147bbed1216)

  - 토큰 자체를 key로 넣어야하기 때문에 토큰에 접근할 수 있는 `JwtAuthenticationFilter` 에서 로그아웃 함수 호출이 이루어집니다. 그래서 컨트롤러 단 함수가 비어있어요. 놀라지 마세요!
   ```java
      // JwtAuthenticationFilter.class
      // 로그아웃 요청이 들어올 경우
      if (((HttpServletRequest) request).getRequestURI().equals("/api/members/logout")) {
          jwtTokenProvider.logout(token);
      }
    ```

  ```java
     // JwtTokenProvider.class
    public void logout(String token) {
        String memberId = getMemberIdByToken(token, jwtSecretKey);
        // ATK 블랙 리스트 처리
        setBlackList(token);
        // RTK 레디스에서 제거
        redisRTKRepository.findAndDeleteById(memberId);
    }
```
  - `JwtTokenProvider.validateToken()` 함수에서 로그아웃된 토큰인지 검증합니당.

## 질문 및 이외 사항 🚩
- 근데 지금 ROLE에 따른 api 접근 권한을 안 막아놨잖아요. 그래서 로그아웃 API가 헤더에 아무것도 안 넣어도 작동은 되는데, 프론트가 헷갈릴 수 있어서 이거 다시 이야기해봐야 할 것 같아요.

## 리뷰어에게 ✨

- 질문 있으면 남겨주세요!
