### PR TITLE
[MS-125] 모집방 엔티티 데이터 추가 및 dto 수정

### DIFF
--- a/src/main/java/com/modutaxi/api/common/util/time/TimeFormatConverter.java
+++ b/src/main/java/com/modutaxi/api/common/util/time/TimeFormatConverter.java
@@ -1,0 +1,24 @@
+package com.modutaxi.api.common.util.time;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class TimeFormatConverter {
+    /**
+     * LocalDateTime을 yyyy.MM.dd (E) 형식으로 변환<br>
+     * 예시 : 2024.05.05 (일)
+     * @return String
+     */
+    public static String convertTimeToDiaryDate(LocalDateTime time) {
+        return time.format(DateTimeFormatter.ofPattern("yyyy.MM.dd (E)").withLocale(Locale.KOREA));
+    }
+    /**
+     * LocalDateTime을 HH:mm 형식으로 변환<br>
+     * 예시 : 02:00
+     * @return String
+     */
+    public static String covertTimeToShortClockTime(LocalDateTime time) {
+        return time.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
@@ -27,11 +27,7 @@ public class RegisterRoomController {
     /**
      * [POST] 방 생성
      */
-    @Operation(summary = "모집방 생성",
-        description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
-            + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**longitude**: 126.65464\n\n\n"
-            + "**latitude**: 37.45169")
+    @Operation(summary = "모집방 생성", description = "모집방을 생성합니다.<br>목적지 거점의 id, 방 태그, 출발지의 경도, 위도, 출발 시각, 출발지 이름, 목표 인원수를 입력 해주세요.<br>방 태그 : **ONLY_WOMAN**, **MANNER**, **STUDENT_CERTIFICATION**")
     @PostMapping
     public ResponseEntity<RoomDetailResponse> createRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
@@ -3,6 +3,7 @@ package com.modutaxi.api.domain.room.controller;
 import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.*;
+import com.modutaxi.api.domain.room.dto.RoomResponseDto.DeleteRoomResponse;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.service.UpdateRoomService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,11 +47,10 @@ public class UpdateRoomController {
      */
     @Operation(summary = "모집방 삭제")
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteRoom(
+    public ResponseEntity<DeleteRoomResponse> deleteRoom(
         @CurrentMember Member member,
         @PathVariable Long id
     ) {
-        updateRoomService.deleteRoom(member, id);
-        return ResponseEntity.ok("삭제 되었습니다.");
+        return ResponseEntity.ok(updateRoomService.deleteRoom(member, id));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/UpdateRoomController.java
@@ -29,11 +29,7 @@ public class UpdateRoomController {
     /**
      * [Patch] 방 정보 수정
      */
-    @Operation(summary = "모집방 업데이트",
-        description = "**RoomTag Enum 종류**\n\n**RoomTagBitMask**: "
-            + "ONLY\\_WOMAN, MANNER, STUDENT\\_CERTIFICATION"
-            + "\n\n\n**longitude**: 126.65464\n\n\n"
-            + "**latitude**: 37.45169")
+    @Operation(summary = "모집방 업데이트", description = "모집방의 데이터를 업데이트합니다.<br>수정할 데이터가 있다면, 목적지 거점의 id, 방 태그, 출발지의 경도, 위도, 출발 시각, 출발지 이름, 목표 인원수를 입력 해주세요.<br>방 태그 : **ONLY_WOMAN**, **MANNER**, **STUDENT_CERTIFICATION**")
     @PatchMapping("/{id}")
     public ResponseEntity<RoomDetailResponse> updateRoom(
         @CurrentMember Member member,
@@ -45,7 +41,7 @@ public class UpdateRoomController {
     /**
      * [Delete] 방 삭제
      */
-    @Operation(summary = "모집방 삭제")
+    @Operation(summary = "모집방 삭제", description = "삭제할 모집방의 id를 입력해주세요.")
     @DeleteMapping("/{id}")
     public ResponseEntity<DeleteRoomResponse> deleteRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomInternalDto.java
@@ -28,11 +28,13 @@ public class RoomInternalDto {
 
         private LocalDateTime departureTime;
 
+        private String departureName;
+
         private int wishHeadcount;
 
         private int expectedCharge;
 
-        private long duration;
+        private long durationMinutes;
 
         public static InternalUpdateRoomDto toDto(Room room) {
             return InternalUpdateRoomDto.builder()
@@ -41,8 +43,9 @@ public class RoomInternalDto {
                 .departureLongitude((float) room.getDeparturePoint().getX())
                 .departureLatitude((float) room.getDeparturePoint().getY())
                 .departureTime(room.getDepartureTime())
+                .departureName(room.getDepartureName())
                 .wishHeadcount(room.getWishHeadcount())
-                .duration(room.getDuration())
+                .durationMinutes(room.getDurationMinutes())
                 .expectedCharge(room.getExpectedCharge())
                 .build();
         }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomRequestDto.java
@@ -17,38 +17,38 @@ public class RoomRequestDto {
     @Builder
     @AllArgsConstructor
     public static class CreateRoomRequest {
-
+        @Schema(description = "도착 거점 id")
         private Long spotId;
-
+        @Schema(description = "택시팟 카테고리")
         private List<RoomTagBitMask> roomTagBitMask;
-
-        @Schema(example = "126.65464", description = "출발지 경도")
+        @Schema(example = "126.68557", description = "출발지 경도")
         private Float departureLongitude;
-
-        @Schema(example = "37.45169", description = "출발지 위도")
+        @Schema(example = "37.46761", description = "출발지 위도")
         private Float departureLatitude;
-
+        @Schema(description = "출발 시각")
         private LocalDateTime departureTime;
-
+        @Schema(example = "센트리빌", description = "출발지 이름")
+        private String departureName;
+        @Schema(description = "목표 인원수")
         private int wishHeadcount;
     }
 
     @Getter
     @Builder
     public static class UpdateRoomRequest {
-
+        @Schema(description = "도착 거점 id")
         private Long spotId;
-
+        @Schema(description = "택시팟 카테고리")
         private List<RoomTagBitMask> roomTagBitMask;
-
-        @Schema(example = "126.65464", description = "출발지 경도")
+        @Schema(example = "126.68557", description = "출발지 경도")
         private Float departureLongitude;
-
-        @Schema(example = "37.45169", description = "출발지 위도")
+        @Schema(example = "37.46761", description = "출발지 위도")
         private Float departureLatitude;
-
+        @Schema(description = "출발 시각")
         private LocalDateTime departureTime;
-
+        @Schema(example = "센트리빌", description = "출발지 이름")
+        private String departureName;
+        @Schema(description = "목표 인원수")
         private int wishHeadcount;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -102,4 +102,11 @@ public class RoomResponseDto {
         @Schema(description = "방 리스트")
         List<SearchWithRadiusResponse> rooms;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class DeleteRoomResponse {
+        @Schema(example = "true", description = "수행완료 여부")
+        private Boolean isDeleted;
+    }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -1,18 +1,13 @@
 package com.modutaxi.api.domain.room.dto;
 
-import static com.modutaxi.api.common.converter.RoomTagBitMaskConverter.convertBitMaskToRoomTagList;
-
-import com.modutaxi.api.domain.room.entity.Room;
 import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import com.mongodb.client.model.geojson.LineString;
-import java.time.LocalDateTime;
-import java.util.List;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.geo.Point;
+
+import java.util.List;
 
 public class RoomResponseDto {
 
@@ -20,89 +15,77 @@ public class RoomResponseDto {
     @Builder
     @AllArgsConstructor
     public static class RoomDetailResponse {
-
+        @Schema(description = "택시팟 id")
         private Long roomId;
-
+        @Schema(description = "도착 거점 id")
         private Long spotId;
-
+        @Schema(example = "2022.05.05 (일)", description = "출발 일자")
+        private String departureDairyDate;
+        @Schema(example = "126.65464", description = "도착지 경도")
+        private Float arrivalLongitude;
+        @Schema(example = "37.45169", description = "도착지 위도")
+        private Float arrivalLatitude;
+        @Schema(example = "14:00", description = "도착 시간")
+        private String arrivalTime;
+        @Schema(example = "주안역", description = "도착 거점 이름")
+        private String arrivalName;
+        @Schema(description = "택시팟 카테고리")
         private List<RoomTagBitMask> roomTagBitMaskList;
-
-        @Schema(example = "126.65464", description = "출발지 경도")
+        @Schema(example = "126.68557", description = "출발지 경도")
         private Float departureLongitude;
-
-        @Schema(example = "37.45169", description = "출발지 위도")
+        @Schema(example = "37.46761", description = "출발지 위도")
         private Float departureLatitude;
-
-        private LocalDateTime departureTime;
-
+        @Schema(example = "12:00", description = "출발 시간")
+        private String departureTime;
+        @Schema(example = "센트리빌", description = "출발지 이름")
+        private String departureName;
+        @Schema(example = "2", description = "현재 인원수")
+        private int currentHeadcount;
+        @Schema(example = "3", description = "목표 인원수")
         private int wishHeadcount;
-
-        private long duration;
-
+        @Schema(example = "30", description = "이동 예상시간 (분)")
+        private long durationMinutes;
+        @Schema(example = "5000", description = "인당 예상 요금(목표 인원 다 찼을 때 기준)")
+        private int expectedChargePerPerson;
+        @Schema(example = "15000", description = "예상 요금")
         private int expectedCharge;
-
+        @Schema(description = "경로")
         private LineString path;
-
-        public static RoomDetailResponse toDto(Room room, LineString path) {
-            return RoomDetailResponse.builder()
-                .roomId(room.getId())
-                .spotId(room.getSpot().getId())
-                .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .departureLongitude((float) room.getDeparturePoint().getX())
-                .departureLatitude((float) room.getDeparturePoint().getY())
-                .departureTime(room.getDepartureTime())
-                .wishHeadcount(room.getWishHeadcount())
-                .duration(room.getDuration())
-                .expectedCharge(room.getExpectedCharge())
-                .path(path)
-                .build();
-        }
     }
 
     @Getter
     @Builder
     @AllArgsConstructor
     public static class RoomSimpleResponse {
-
+        @Schema(description = "택시팟 id")
         private Long roomId;
-
+        @Schema(description = "도착 거점 id")
         private Long spotId;
-
+        @Schema(example = "14:00", description = "도착 시간")
+        private String arrivalTime;
+        @Schema(example = "주안역", description = "도착 거점 이름")
+        private String arrivalName;
+        @Schema(description = "택시팟 카테고리")
         private List<RoomTagBitMask> roomTagBitMaskList;
-
-        @Schema(example = "126.65464", description = "출발지 경도")
-        private Float departureLongitude;
-
-        @Schema(example = "37.45169", description = "출발지 위도")
-        private Float departureLatitude;
-
-        private LocalDateTime departureTime;
-
+        @Schema(example = "12:00", description = "출발 시간")
+        private String departureTime;
+        @Schema(example = "센트리빌", description = "출발지 이름")
+        private String departureName;
+        @Schema(example = "2", description = "현재 인원수")
+        private int currentHeadcount;
+        @Schema(example = "3", description = "목표 인원수")
         private int wishHeadcount;
-
-        private long duration;
-
+        @Schema(example = "30", description = "이동 예상시간 (분)")
+        private long durationMinutes;
+        @Schema(example = "5000", description = "인당 예상 요금(목표 인원 다 찼을 때 기준)")
+        private int expectedChargePerPerson;
+        @Schema(example = "15000", description = "예상 요금")
         private int expectedCharge;
-
-        public static RoomSimpleResponse toDto(Room room) {
-            return RoomSimpleResponse.builder()
-                .roomId(room.getId())
-                .spotId(room.getSpot().getId())
-                .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
-                .departureLongitude((float) room.getDeparturePoint().getX())
-                .departureLatitude((float) room.getDeparturePoint().getY())
-                .departureTime(room.getDepartureTime())
-                .wishHeadcount(room.getWishHeadcount())
-                .duration(room.getDuration())
-                .expectedCharge(room.getExpectedCharge())
-                .build();
-        }
     }
 
     @Getter
     @AllArgsConstructor
     public static class SearchWithRadiusResponse {
-
         @Schema(example = "2", description = "방 id")
         private Long id;
         @Schema(example = "126.65464", description = "출발지 경도")
@@ -116,7 +99,6 @@ public class RoomResponseDto {
     @Getter
     @AllArgsConstructor
     public static class SearchWithRadiusResponses {
-
         @Schema(description = "방 리스트")
         List<SearchWithRadiusResponse> rooms;
     }

--- a/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
+++ b/src/main/java/com/modutaxi/api/domain/room/entity/Room.java
@@ -42,7 +42,7 @@ public class Room extends BaseTime {
 
     @NotNull
     @Builder.Default
-    private long duration = 3600000;
+    private long durationMinutes = 3600000;
 
     @NotNull
     @Builder.Default
@@ -56,8 +56,15 @@ public class Room extends BaseTime {
     private Point departurePoint = null;
 
     @NotNull
+    private String departureName;
+
+    @NotNull
     @Builder.Default
     private LocalDateTime departureTime = LocalDateTime.now();
+
+    @NotNull
+    @Builder.Default
+    private int currentHeadcount = 0;
 
     @NotNull
     @Builder.Default
@@ -71,9 +78,10 @@ public class Room extends BaseTime {
         Coordinate coordinate
             = new Coordinate(updateRoomDto.getDepartureLongitude(), updateRoomDto.getDepartureLatitude());
         this.departurePoint = geometryFactory.createPoint(coordinate);
+        this.departureName = updateRoomDto.getDepartureName();
         this.departureTime = updateRoomDto.getDepartureTime();
         this.wishHeadcount = updateRoomDto.getWishHeadcount();
         this.expectedCharge = updateRoomDto.getExpectedCharge();
-        this.duration = updateRoomDto.getDuration();
+        this.durationMinutes = updateRoomDto.getDurationMinutes();
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
@@ -1,14 +1,20 @@
 package com.modutaxi.api.domain.room.mapper;
 
+import com.modutaxi.api.common.util.time.TimeFormatConverter;
 import com.modutaxi.api.domain.member.entity.Member;
+import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
+import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomSimpleResponse;
 import com.modutaxi.api.domain.room.entity.Room;
-import java.time.LocalDateTime;
-
 import com.modutaxi.api.domain.spot.entity.Spot;
+import com.mongodb.client.model.geojson.LineString;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+import static com.modutaxi.api.common.converter.RoomTagBitMaskConverter.convertBitMaskToRoomTagList;
 
 @Component
 public class RoomMapper {
@@ -17,11 +23,13 @@ public class RoomMapper {
         Member member,
         Spot spot,
         int expectedCharge,
-        long duration,
+        long durationMinutes,
         int roomTagBitMask,
         float departureLongitude,
         float departureLatitude,
-        LocalDateTime departureTime
+        LocalDateTime departureTime,
+        String departureName,
+        int wishHeadcount
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate = new Coordinate(departureLongitude, departureLatitude);
@@ -30,10 +38,52 @@ public class RoomMapper {
             .spot(spot)
             .roomManager(member)
             .expectedCharge(expectedCharge)
-            .duration(duration)
+            .durationMinutes(durationMinutes)
             .roomTagBitMask(roomTagBitMask)
             .departureTime(departureTime)
             .departurePoint(point)
+            .departureName(departureName)
+            .wishHeadcount(wishHeadcount)
+            .build();
+    }
+
+    public static RoomDetailResponse toDto(Room room, LineString path) {
+        return RoomDetailResponse.builder()
+            .roomId(room.getId())
+            .spotId(room.getSpot().getId())
+            .departureDairyDate(TimeFormatConverter.convertTimeToDiaryDate(room.getDepartureTime()))
+            .arrivalLongitude((float) room.getSpot().getSpotPoint().getX())
+            .arrivalLatitude((float) room.getSpot().getSpotPoint().getY())
+            .arrivalTime(TimeFormatConverter.covertTimeToShortClockTime(room.getDepartureTime().plusMinutes(room.getDurationMinutes())))
+            .arrivalName(room.getSpot().getName())
+            .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
+            .departureLongitude((float) room.getDeparturePoint().getX())
+            .departureLatitude((float) room.getDeparturePoint().getY())
+            .departureTime(TimeFormatConverter.covertTimeToShortClockTime(room.getDepartureTime()))
+            .departureName(room.getDepartureName())
+            .currentHeadcount(room.getCurrentHeadcount())
+            .wishHeadcount(room.getWishHeadcount())
+            .durationMinutes(room.getDurationMinutes())
+            .expectedChargePerPerson((room.getExpectedCharge()) / (room.getWishHeadcount() + 1))
+            .expectedCharge(room.getExpectedCharge())
+            .path(path)
+            .build();
+    }
+
+    public static RoomSimpleResponse toDto(Room room) {
+        return RoomSimpleResponse.builder()
+            .roomId(room.getId())
+            .spotId(room.getSpot().getId())
+            .arrivalTime(TimeFormatConverter.covertTimeToShortClockTime(room.getDepartureTime().plusMinutes(room.getDurationMinutes())))
+            .arrivalName(room.getSpot().getName())
+            .roomTagBitMaskList(convertBitMaskToRoomTagList(room.getRoomTagBitMask()))
+            .departureTime(TimeFormatConverter.covertTimeToShortClockTime(room.getDepartureTime()))
+            .departureName(room.getDepartureName())
+            .currentHeadcount(room.getCurrentHeadcount())
+            .wishHeadcount(room.getWishHeadcount())
+            .durationMinutes(room.getDurationMinutes())
+            .expectedChargePerPerson((room.getExpectedCharge()) / (room.getWishHeadcount() + 1))
+            .expectedCharge(room.getExpectedCharge())
             .build();
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
@@ -12,6 +12,7 @@ import com.modutaxi.api.domain.room.dto.RoomResponseDto.SearchWithRadiusResponse
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.SearchWithRadiusResponses;
 import com.modutaxi.api.domain.room.entity.Room;
 
+import com.modutaxi.api.domain.room.mapper.RoomMapper;
 import com.modutaxi.api.domain.room.mapper.RoomResponseMapper;
 import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
@@ -50,14 +51,14 @@ public class GetRoomService {
             .orElseThrow(() -> new BaseException(
                 TaxiInfoErrorCode.EMPTY_TAXI_INFO)).getPath();
 
-        return RoomDetailResponse.toDto(room, path);
+        return RoomMapper.toDto(room, path);
     }
 
     public PageResponseDto<List<RoomSimpleResponse>> getRoomSimpleList(int page, int size, Long spotId, List<RoomTagBitMask> tags, Boolean isImminent) {
         Pageable pageable = PageRequest.of(page, size);
         Slice<Room> roomSlice = getRoomSlice(pageable, spotId, checkTags(tags), isImminent);
         List<RoomSimpleResponse> roomSimpleResponseList = roomSlice.stream()
-            .map(RoomSimpleResponse::toDto)
+            .map(RoomMapper::toDto)
             .collect(Collectors.toList());
 
         return new PageResponseDto<>(pageable.getPageNumber(), roomSlice.hasNext(),

--- a/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.domain.room.service;
 
 import static com.modutaxi.api.common.converter.RoomTagBitMaskConverter.convertRoomTagListToBitMask;
+import static org.joda.time.DateTimeConstants.MILLIS_PER_MINUTE;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.modutaxi.api.common.converter.NaverMapConverter;
@@ -62,21 +63,26 @@ public class RegisterRoomService {
 
         int expectedCharge = taxiInfo.get("taxiFare").asInt();
 
-        long duration = taxiInfo.get("duration").asLong();
+        long durationMinutes = taxiInfo.get("duration").asLong() / MILLIS_PER_MINUTE;
 
-        Room room = RoomMapper.toEntity(member, spot,
-            expectedCharge, duration,
-            convertRoomTagListToBitMask(
-                createRoomRequest.getRoomTagBitMask()),
-            createRoomRequest.getDepartureLongitude(), createRoomRequest.getDepartureLatitude(),
-            createRoomRequest.getDepartureTime()
+        Room room = RoomMapper.toEntity(
+            member,
+            spot,
+            expectedCharge,
+            durationMinutes,
+            convertRoomTagListToBitMask(createRoomRequest.getRoomTagBitMask()),
+            createRoomRequest.getDepartureLongitude(),
+            createRoomRequest.getDepartureLatitude(),
+            createRoomRequest.getDepartureTime(),
+            createRoomRequest.getDepartureName(),
+            createRoomRequest.getWishHeadcount()
         );
 
         LineString path = NaverMapConverter.jsonNodeToLineString(taxiInfo.get("path"));
 
         roomRepository.save(room);
         registerTaxiInfoService.savePath(room.getId(), path);
-        return RoomDetailResponse.toDto(room, path);
+        return RoomMapper.toDto(room, path);
     }
 
     private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -15,6 +15,7 @@ import com.modutaxi.api.domain.room.dto.RoomRequestDto.UpdateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.entity.Room;
 import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
+import com.modutaxi.api.domain.room.mapper.RoomMapper;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
 import com.modutaxi.api.domain.spot.repository.SpotRepository;
 import com.modutaxi.api.domain.taxiinfo.entity.TaxiInfo;
@@ -25,6 +26,8 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static org.joda.time.DateTimeConstants.MILLIS_PER_MINUTE;
 
 @RequiredArgsConstructor
 @Service
@@ -63,7 +66,7 @@ public class UpdateRoomService {
 
         room.update(newRoomData);
 
-        return RoomDetailResponse.toDto(room, path);
+        return RoomMapper.toDto(room, path);
     }
 
     @Transactional
@@ -147,6 +150,13 @@ public class UpdateRoomService {
             throw new BaseException(RoomErrorCode.DEPARTURE_EXCEED_RANGE);
         }
 
+        // 출발지 이름 업데이트
+        oldRoomData.setDepartureName(
+            updateRoomRequest.getDepartureName() != null
+                ? updateRoomRequest.getDepartureName()
+                : oldRoomData.getDepartureName()
+        );
+
         return oldRoomData;
     }
 
@@ -167,7 +177,7 @@ public class UpdateRoomService {
         LineString path = NaverMapConverter.jsonNodeToLineString(jsonNode.get("path"));
 
         internalUpdateRoomDto.setExpectedCharge(jsonNode.get("taxiFare").asInt());
-        internalUpdateRoomDto.setDuration(jsonNode.get("duration").asLong());
+        internalUpdateRoomDto.setDurationMinutes(jsonNode.get("duration").asLong() / MILLIS_PER_MINUTE);
 
         taxiInfoMongoRepository.save(TaxiInfo.toEntity(roomId, path));
         return path;

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -12,6 +12,7 @@ import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dto.RoomInternalDto.InternalUpdateRoomDto;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.CreateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.UpdateRoomRequest;
+import com.modutaxi.api.domain.room.dto.RoomResponseDto.DeleteRoomResponse;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.entity.Room;
 import com.modutaxi.api.domain.room.entity.RoomTagBitMask;
@@ -70,7 +71,7 @@ public class UpdateRoomService {
     }
 
     @Transactional
-    public void deleteRoom(Member member, Long roomId) {
+    public DeleteRoomResponse deleteRoom(Member member, Long roomId) {
         Room room = roomRepository.findById(roomId)
             .orElseThrow(() -> new BaseException(RoomErrorCode.EMPTY_ROOM));
         TaxiInfo taxiInfo = taxiInfoMongoRepository.findById(roomId)
@@ -80,6 +81,7 @@ public class UpdateRoomService {
 
         roomRepository.delete(room);
         taxiInfoMongoRepository.delete(taxiInfo);
+        return new DeleteRoomResponse(true);
     }
 
     private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {


### PR DESCRIPTION
## 요약 🎀
- 모집방 엔티티 데이터 추가 및 dto 수정

## 상세 내용 🌈
- 모집방 엔티티 데이터 추가하였습니다.
  - 모호하던 데이터명 duration을 durationMinutes 으로 변경하였습니다. (기존의 ms 단위이던 값을 분 단위로 변경)
  - 출발지의 이름을 저장하는 departureName 을 추가하였습니다.
  - 현재 택시팟의 인원을 저장하는 currentHeadcount 을 추가하였습니다.
- 기존의 dto에서 `toDto` 함수를 정의하던 방식에서 Mapper 방식으로 변경하였습니다.
  - `RoomMapper`
- 기존의 생성시에 모집 목표 인원이 저장되지 않던 버그를 수정하였습니다.
- 시간 데이터 반환 시, 프론트에서 시간 형식을 변경하지 않아도 되도록 `TimeFormatConverter` 를 사용하여 변환 후 반환합니다.
- `/api/rooms` 아래의 DTO의 데이터를 추가하였습니다.
  - Request
    - 출발지 이름
  - Response
    - 출발 일자, 위도, 경도, 시간, 이름
    - 도착지 이름
    - 현재 인원
    - 이동 시간 (ms 에서 분 단위로 변경)
    - 인당 예상 금액
- 모집방 제거 API의 반환 dto를 생성하였습니다.
- 모집방 생성, 제거, 수정 API 의 스웨거 설명을 수정하였습니다.
## 리뷰어에게 ✨
- `currentHeadcount` 의 경우는 추후에 채팅 브랜치가 합쳐진 후 업데이트 로직을 추가 구현이 필요합니다. @tjdgns8439 
