### PR TITLE
[MS-147] 도착지 지도 조회 최소개수 조회 방식으로 변경

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
@@ -128,13 +128,14 @@ public class GetSpotController {
         @ApiResponse(responseCode = "200", description = "거점 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SearchSpotWithRadiusResponses.class))),
     })
     public ResponseEntity<SearchSpotWithRadiusResponses> getRadiusSpots(
+        @Parameter(description = "검색 거점 개수") @RequestParam(defaultValue = "3") int count,
         @Parameter(description = "검색 기준 경도") @RequestParam Float searchLongitude,
         @Parameter(description = "검색 기준 위도") @RequestParam Float searchLatitude
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate = new Coordinate(searchLongitude, searchLatitude);
         Point point = geometryFactory.createPoint(coordinate);
-        return ResponseEntity.ok(getSpotService.getRadiusSpots(point));
+        return ResponseEntity.ok(getSpotService.getRadiusSpots(point, count));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/controller/GetSpotController.java
@@ -128,14 +128,13 @@ public class GetSpotController {
         @ApiResponse(responseCode = "200", description = "거점 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = SearchSpotWithRadiusResponses.class))),
     })
     public ResponseEntity<SearchSpotWithRadiusResponses> getRadiusSpots(
-        @Parameter(description = "거리 반경<br>단위: 미터<br>기본값: 500m") @RequestParam(defaultValue = "500", required = false) Long radius,
         @Parameter(description = "검색 기준 경도") @RequestParam Float searchLongitude,
         @Parameter(description = "검색 기준 위도") @RequestParam Float searchLatitude
     ) {
         GeometryFactory geometryFactory = new GeometryFactory();
         Coordinate coordinate = new Coordinate(searchLongitude, searchLatitude);
         Point point = geometryFactory.createPoint(coordinate);
-        return ResponseEntity.ok(getSpotService.getRadiusSpots(point, radius));
+        return ResponseEntity.ok(getSpotService.getRadiusSpots(point));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/modutaxi/api/domain/spot/dao/SpotMysqlResponse.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/dao/SpotMysqlResponse.java
@@ -25,5 +25,7 @@ public class SpotMysqlResponse {
         String getAddress();
 
         Point getSpotPoint();
+
+        Double getDistance();
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/spot/dto/SpotResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/dto/SpotResponseDto.java
@@ -93,6 +93,8 @@ public class SpotResponseDto {
     @Getter
     @AllArgsConstructor
     public static class SearchSpotWithRadiusResponses {
+        @Schema(example = "3204.821669916938", description = "최대 거리, 미터단위")
+        Double distance;
         @Schema(description = "거점 리스트")
         List<SearchSpotWithRadiusResponse> spots;
     }

--- a/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/repository/SpotRepository.java
@@ -32,14 +32,13 @@ public interface SpotRepository extends JpaRepository<Spot, Long> {
     List<Spot> findAreaSpotsByPolygon(@Param("polygon") Polygon polygon);
 
     @Query("SELECT " +
-        "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotPoint " +
+        "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotPoint, ST_DISTANCE_SPHERE(:point, s.spotPoint) distance " +
         "FROM Spot s " +
-        "WHERE " +
-        "ST_DISTANCE_SPHERE(:point, s.spotPoint) <= :radius " +
         "ORDER BY " +
-        "ST_DISTANCE_SPHERE(:point, s.spotPoint)"
+        "ST_DISTANCE_SPHERE(:point, s.spotPoint) " +
+        "ASC LIMIT :limit"
     )
-    List<SearchWithRadiusResponseInterface> findNearSpotsInRadius(@Param("point") Point point, @Param("radius") Long radius);
+    List<SearchWithRadiusResponseInterface> findNearSpotsInRadius(@Param("point") Point point, @Param("limit") int limit);
 
     @Query("SELECT " +
         "s.id AS id, s.name AS name, s.address AS address, s.spotPoint AS spotpoint, (CASE WHEN :currentPoint IS NULL THEN NULL ELSE ST_DISTANCE_SPHERE(:currentPoint, s.spotPoint) END) AS distance, (CASE WHEN l.member = :member THEN true ELSE false END) AS liked " +

--- a/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
@@ -23,7 +23,6 @@ import static com.modutaxi.api.common.exception.errorcode.SpotError.SPOT_ID_NOT_
 @Service
 public class GetSpotService {
     private final SpotRepository spotRepository;
-    private final int mapSearchLimit = 3;
 
     public Spot getSpot(Long id) {
         return spotRepository.findById(id).orElseThrow(
@@ -44,7 +43,7 @@ public class GetSpotService {
         return new GetSpotResponses(spotList);
     }
 
-    public SearchSpotWithRadiusResponses getRadiusSpots(Point searchPoint) {
+    public SearchSpotWithRadiusResponses getRadiusSpots(Point searchPoint, int mapSearchLimit) {
         List<SearchWithRadiusResponseInterface> spots = spotRepository.findNearSpotsInRadius(searchPoint, mapSearchLimit);
         List<SearchSpotWithRadiusResponse> spotList = spots.stream().map(SpotResponseMapper::toSearchWithRadiusResponse).toList();
         Double maxDistance = spots.stream().mapToDouble(v -> v.getDistance()).max().orElse(500.0);

--- a/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
+++ b/src/main/java/com/modutaxi/api/domain/spot/service/GetSpotService.java
@@ -23,6 +23,7 @@ import static com.modutaxi.api.common.exception.errorcode.SpotError.SPOT_ID_NOT_
 @Service
 public class GetSpotService {
     private final SpotRepository spotRepository;
+    private final int mapSearchLimit = 3;
 
     public Spot getSpot(Long id) {
         return spotRepository.findById(id).orElseThrow(
@@ -43,10 +44,11 @@ public class GetSpotService {
         return new GetSpotResponses(spotList);
     }
 
-    public SearchSpotWithRadiusResponses getRadiusSpots(Point searchPoint, Long radius) {
-        List<SearchWithRadiusResponseInterface> spots = spotRepository.findNearSpotsInRadius(searchPoint, radius);
+    public SearchSpotWithRadiusResponses getRadiusSpots(Point searchPoint) {
+        List<SearchWithRadiusResponseInterface> spots = spotRepository.findNearSpotsInRadius(searchPoint, mapSearchLimit);
         List<SearchSpotWithRadiusResponse> spotList = spots.stream().map(SpotResponseMapper::toSearchWithRadiusResponse).toList();
-        return new SearchSpotWithRadiusResponses(spotList);
+        Double maxDistance = spots.stream().mapToDouble(v -> v.getDistance()).max().orElse(500.0);
+        return new SearchSpotWithRadiusResponses(maxDistance, spotList);
     }
 
     public GetSpotWithDistanceResponses getNearSpots(Member member, Point currentPoint, Point searchPoint, int page, int size) {


### PR DESCRIPTION
## 요약 🎀
- 도착지 지도 조회 최소개수 조회 방식으로 변경

## 상세 내용 🌈
- 도착지 지도 조회 최소개수 조회 방식으로 변경
  - 지도로 보여줄 도착지를 조회 반경 기준이 아닌 조회 갯수 기준으로 변경하였습니다.

## 질문 및 이외 사항 🚩
- 조회 갯수를 백엔드의 코드로 저장하여 고정적인 숫자 3개로 지정해 요청하는것이 좋을지, 아니면 Request를 받을때 Parameter로 받으면서 Default 값을 지정하여 함께 보내지 않을시에는 3개로요청하고 함께 요청할시에는 해당 갯수만큼 거점이 존재하는 결과를 반환하는것이 좋을지 고민입니다. 어떤 방식이 좋을까요?
- 그럴일이 많이 없을것 같지만, 검색 위치에서 가까운 순으로 3개의 데이터를 조회하기 때문에 지도에서 보여주는 영역내에 거점이 4개 이상으로 존재하지만 표현이 되지 않는 경우가 존재할수도 있을것 같습니다. 이부분은 무시하고 진행하는것이 나을까요? 아니면 어쨋든 이부분까지 다 보여줘야한다고 생각하시나요?

## 리뷰어에게 ✨
- PostgreSQL로의 전환이 필요한것은 조회 속도에서의 측면에서 확실하지만 아직까지는 조회에 있어서 반응속도가 나쁘지 않다고 판단되어 PostgreSQL로의 전환은 늦추는것이 좋을것 같습니다. 제가 개발했던 커스텀 Dialect 관련해서도 작업할 부분이 꽤 있어서 기능 개발이 다 진행된 후 전환하는것이 좋을것 같습니다.