### PR TITLE
[MS-146] 신고하기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ dependencies {
 
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    // Slack
+    implementation 'com.slack.api:slack-api-client:1.30.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/modutaxi/api/common/constants/ServerConstants.java
+++ b/src/main/java/com/modutaxi/api/common/constants/ServerConstants.java
@@ -4,4 +4,7 @@ public final class ServerConstants {
 
     // 프로필 기본 이미지
     public static final String BASIC_PROFILE_IMAGE_URL = "임시 링크";
+
+    // 신고 누적 처리 기준
+    public static final int REPORT_STANDARD = 5;
 }

--- a/src/main/java/com/modutaxi/api/common/constants/ServerConstants.java
+++ b/src/main/java/com/modutaxi/api/common/constants/ServerConstants.java
@@ -12,6 +12,7 @@ public final class ServerConstants {
     private String basicProfileImageUrl;
 
     public static String BASIC_PROFILE_IMAGE_URL;
+    public static final int REPORT_STANDARD = 5;
 
     @PostConstruct
     private void init() {

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/MemberErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/MemberErrorCode.java
@@ -20,6 +20,8 @@ public enum MemberErrorCode implements ErrorCode {
     TOO_LONG_NICKNAME("MEMBER_008", "닉네임은 최대 12글자까지 가능해요!", HttpStatus.BAD_REQUEST),
     INAPPROPRIATE_WORD_NICKNAME("MEMBER_009", "비속어 혹은 부적절한 단어가 포함된 닉네임은 생성할 수 없어요!",
         HttpStatus.BAD_REQUEST),
+
+    BLOCKED_MEMBER("MEMBER_010", "임시 차단된 사용자입니다.", HttpStatus.UNAUTHORIZED),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/ReportErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/ReportErrorCode.java
@@ -1,0 +1,18 @@
+package com.modutaxi.api.common.exception.errorcode;
+
+import com.modutaxi.api.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReportErrorCode implements ErrorCode {
+    SHORT_CONTENT("REPORT_001", "신고 사유는 10자 이상 입력해주세요.", HttpStatus.BAD_REQUEST),
+    SELF_REPORT("REPORT_002", "자신은 신고할 수 없습니다.", HttpStatus.CONFLICT),
+    ;
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/modutaxi/api/common/slack/Color.java
+++ b/src/main/java/com/modutaxi/api/common/slack/Color.java
@@ -1,0 +1,18 @@
+package com.modutaxi.api.common.slack;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Color {
+
+    GREEN("#36a64f"),
+    RED("#ff0000"),
+    BLUE("#0000ff"),
+    YELLOW("#ffff00"),
+    BLACK("#000000"),
+    WHITE("#ffffff");
+
+    private final String code;
+}

--- a/src/main/java/com/modutaxi/api/common/slack/SlackService.java
+++ b/src/main/java/com/modutaxi/api/common/slack/SlackService.java
@@ -54,10 +54,10 @@ public class SlackService {
     public void sendReportMessage(Report report) {
         String title = "새로운 신고가 접수되었습니다!";
         HashMap<String, String> data = new HashMap<>();
-        data.put("신고자 ID", Long.toString(report.getReporterId()));
-        data.put("신고 대상자 ID", Long.toString(report.getTargetId()));
-        data.put("신고 유형", report.getType().getMessage());
-        data.put("신고 내용", report.getContent());
+        data.put("0. 신고자 ID", Long.toString(report.getReporterId()));
+        data.put("1. 신고 대상자 ID", Long.toString(report.getTargetId()));
+        data.put("2. 신고 유형", report.getType().getMessage());
+        data.put("3. 신고 내용", report.getContent());
 
         sendMessage(reportSlackToken, title, data, Color.GREEN.getCode());
     }

--- a/src/main/java/com/modutaxi/api/common/slack/SlackService.java
+++ b/src/main/java/com/modutaxi/api/common/slack/SlackService.java
@@ -1,0 +1,87 @@
+package com.modutaxi.api.common.slack;
+
+import static com.slack.api.webhook.WebhookPayloads.payload;
+
+import com.modutaxi.api.domain.member.entity.Member;
+import com.modutaxi.api.domain.report.entity.Report;
+import com.slack.api.Slack;
+import com.slack.api.model.Attachment;
+import com.slack.api.model.Field;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SlackService {
+
+    private final Slack slackClient = Slack.getInstance();
+
+    @Value("${slack.webhook-uri.report}")
+    private String reportSlackToken;
+
+    /**
+     * 슬랙 메시지 전송
+     *
+     * @Param token 전송할 채널의 웹훅 토큰
+     * @Param title 메시지의 제목
+     * @Param 메시지 데이터 셋
+     * @Param 메시지 컬러 코드
+     **/
+    public void sendMessage(String token, String title, HashMap<String, String> data,
+        String colorCode) {
+        try {
+            slackClient.send(token, payload(p -> p
+                .text(title) // 메시지 제목
+                .attachments(List.of(
+                    Attachment.builder().color(colorCode) // 메시지 색상
+                        .fields( // 메시지 본문 내용
+                            data.keySet().stream()
+                                .map(key -> generateSlackField(key, data.get(key))).collect(
+                                    Collectors.toList())
+                        ).build())))
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 신고 발생 시 슬랙 메시지 전송
+     **/
+    public void sendReportMessage(Report report) {
+        String title = "새로운 신고가 접수되었습니다!";
+        HashMap<String, String> data = new HashMap<>();
+        data.put("신고자 ID", Long.toString(report.getReporterId()));
+        data.put("신고 대상자 ID", Long.toString(report.getTargetId()));
+        data.put("신고 유형", report.getType().getMessage());
+        data.put("신고 내용", report.getContent());
+
+        sendMessage(reportSlackToken, title, data, Color.GREEN.getCode());
+    }
+
+    /**
+     * 신고 누적으로 인한 임시 차단 멤버 발생 시 슬랙 메시지 전송
+     **/
+    public void sendTemporaryBlockMemberMessage(Member member) {
+        String title = "신고 누적으로 인해 임시 차단 멤버가 발생했습니다!";
+        HashMap<String, String> data = new HashMap<>();
+        data.put("멤버 ID", Long.toString(member.getId()));
+        data.put("닉네임", member.getNickname());
+
+        sendMessage(reportSlackToken, title, data, Color.RED.getCode());
+    }
+
+    /**
+     * Slack Field 생성
+     **/
+    private Field generateSlackField(String title, String value) {
+        return Field.builder()
+            .title(title)
+            .value(value)
+            .valueShortEnough(false)
+            .build();
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
@@ -2,9 +2,14 @@ package com.modutaxi.api.domain.mail.service;
 
 public interface MailService {
     Boolean sendEmailCertificationMail(Long memberId, String emailAddress);
+
     Boolean checkMailDomain(String emailAddress);
+
     String checkEmailCertificationCode(Long memberId, String certificationCode);
+
     void sendCoolSmsBalanceMessage(Long balance);
+
     void sendAligoRemainSmsMessage(String smsCnt);
+
     void sendTemporaryBlockMemberMail(String emailAddress);
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailService.java
@@ -6,4 +6,5 @@ public interface MailService {
     String checkEmailCertificationCode(Long memberId, String certificationCode);
     void sendCoolSmsBalanceMessage(Long balance);
     void sendAligoRemainSmsMessage(String smsCnt);
+    void sendTemporaryBlockMemberMail(String emailAddress);
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
@@ -5,11 +5,10 @@ import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.domain.mail.dao.CertCodeEntity;
 import com.modutaxi.api.domain.mail.repository.RedisMailCertCodeRepository;
 import com.modutaxi.api.domain.mail.vo.MailDomain;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -59,5 +58,10 @@ public class MailServiceImpl implements MailService {
     @Override
     public void sendAligoRemainSmsMessage(String smsCnt) {
         mailUtil.sendAligoRemainSmsMail(smsCnt);
+    }
+
+    @Override
+    public void sendTemporaryBlockMemberMail(String emailAddress) {
+        mailUtil.sendBlockMemberNotificationMail(emailAddress);
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailServiceImpl.java
@@ -23,7 +23,8 @@ public class MailServiceImpl implements MailService {
         CertCodeEntity certCodeEntity = redisMailCertCodeRepository.findById(memberId);
         if (certCodeEntity != null
             && certCodeEntity.getEmailAddress().equals(emailAddress)
-            && certCodeEntity.getCreatedAt().plusSeconds(certMailRestrictionSeconds).isAfter(LocalDateTime.now())
+            && certCodeEntity.getCreatedAt().plusSeconds(certMailRestrictionSeconds)
+            .isAfter(LocalDateTime.now())
         ) {
             throw new BaseException(MailErrorCode.TOO_MANY_CERTIFICATION_CODE_REQUEST);
         }

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
@@ -1,7 +1,17 @@
 package com.modutaxi.api.domain.mail.service;
 
+import static com.modutaxi.api.common.exception.errorcode.MailErrorCode.SES_SERVER_ERROR;
+
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.model.*;
+import com.amazonaws.services.simpleemail.model.Body;
+import com.amazonaws.services.simpleemail.model.Content;
+import com.amazonaws.services.simpleemail.model.Destination;
+import com.amazonaws.services.simpleemail.model.Message;
+import com.amazonaws.services.simpleemail.model.RawMessage;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendEmailResult;
+import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
 import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.util.cert.CertificationCodeUtil;
 import com.modutaxi.api.domain.mail.vo.MailTemplate;
@@ -10,19 +20,19 @@ import jakarta.activation.DataSource;
 import jakarta.activation.FileDataSource;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
-import jakarta.mail.internet.*;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Properties;
-
-import static com.modutaxi.api.common.exception.errorcode.MailErrorCode.SES_SERVER_ERROR;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
@@ -71,7 +81,16 @@ public class MailUtil {
         }
     }
 
-    private SendEmailResult sendSimpleEmailOnlyHtml(String title, String sender, String htmlContent, String receiver) {
+    public void sendBlockMemberNotificationMail(String receiver) {
+        sendSimpleEmailOnlyHtml(
+            "[모두의 택시] 신고 누적으로 인해 귀하의 계정이 임시 차단되었습니다."
+            , noReplySender
+            , MailTemplate.getTemporaryBlockMemberMailContent(receiver)
+            , receiver);
+    }
+
+    private SendEmailResult sendSimpleEmailOnlyHtml(String title, String sender, String htmlContent,
+        String receiver) {
         Message message = new Message();
         message.setSubject(new Content(title));
         message.setBody(new Body().withHtml(new Content(htmlContent)));

--- a/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/service/MailUtil.java
@@ -62,10 +62,10 @@ public class MailUtil {
     public void sendEmailCoolSmsBalanceMail(Long balance) {
         for (String bankerEmail : bankerEmailList) {
             sendSimpleEmailOnlyHtml(
-                    "[모두의 택시] Cool SMS 잔액 부족"
-                    , noReplySender
-                    , String.format("Cool SMS의 잔액이 %s원 남았습니다. 요금을 충전하세요.", balance)
-                    , bankerEmail
+                "[모두의 택시] Cool SMS 잔액 부족"
+                , noReplySender
+                , String.format("Cool SMS의 잔액이 %s원 남았습니다. 요금을 충전하세요.", balance)
+                , bankerEmail
             );
         }
     }
@@ -95,16 +95,20 @@ public class MailUtil {
         message.setSubject(new Content(title));
         message.setBody(new Body().withHtml(new Content(htmlContent)));
 
-        SendEmailRequest request = new SendEmailRequest(sender, new Destination().withToAddresses(receiver), message);
+        SendEmailRequest request = new SendEmailRequest(sender,
+            new Destination().withToAddresses(receiver), message);
         SendEmailResult result = amazonSimpleEmailService.sendEmail(request);
         if (result.getSdkHttpMetadata().getHttpStatusCode() != 200) {
-            throw new BaseException(SES_SERVER_ERROR, "메일 발송에 실패했습니다.\n" + result.getSdkHttpMetadata().toString());
+            throw new BaseException(SES_SERVER_ERROR,
+                "메일 발송에 실패했습니다.\n" + result.getSdkHttpMetadata().toString());
         }
         return result;
     }
 
     // full content mail
-    private SendRawEmailResult sendRawEmail(String title, String sender, String content, String receiver, String html, String fileRoot) throws MessagingException, IOException, NullPointerException {
+    private SendRawEmailResult sendRawEmail(String title, String sender, String content,
+        String receiver, String html, String fileRoot)
+        throws MessagingException, IOException, NullPointerException {
         Session session = Session.getDefaultInstance(new Properties());
         MimeMessage message = new MimeMessage(session);
 
@@ -115,7 +119,8 @@ public class MailUtil {
         message.setFrom(sender);
 
         // 메일 수신자 설정
-        message.setRecipients(jakarta.mail.Message.RecipientType.TO, InternetAddress.parse(receiver));
+        message.setRecipients(jakarta.mail.Message.RecipientType.TO,
+            InternetAddress.parse(receiver));
         MimeMultipart messageBody = new MimeMultipart("alternative");
 
         // HTML, text wrapper 설정
@@ -151,7 +156,8 @@ public class MailUtil {
         // outputStream을 RawMessage로 변환
         RawMessage rawMessage = new RawMessage(ByteBuffer.wrap(outputStream.toByteArray()));
 
-        SendRawEmailResult result = amazonSimpleEmailService.sendRawEmail(new SendRawEmailRequest(rawMessage));
+        SendRawEmailResult result = amazonSimpleEmailService.sendRawEmail(
+            new SendRawEmailRequest(rawMessage));
         return result;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/mail/vo/MailTemplate.java
+++ b/src/main/java/com/modutaxi/api/domain/mail/vo/MailTemplate.java
@@ -1,5 +1,7 @@
 package com.modutaxi.api.domain.mail.vo;
 
+import static com.modutaxi.api.common.constants.ServerConstants.REPORT_STANDARD;
+
 public class MailTemplate {
     public static String getCertMailContent(String email, String certCode) {
         return "<!DOCTYPE html>\n" +
@@ -8,33 +10,40 @@ public class MailTemplate {
             "    <meta charset=\"UTF-8\">\n" +
             "</head>\n" +
             "<body>\n" +
-            "<div style=\"background-color: #3ed0ac; height: 150px; display: flex; align-items: center;\">\n" +
-            "    <span style=\"font-family: Gill Sans; font-weight: bold; font-size: 50px; color: #ffffff; text-shadow: 0px 4px 4px #404040; position: relative; left: 20px\">\n" +
+            "<div style=\"background-color: #3ed0ac; height: 150px; display: flex; align-items: center;\">\n"
+            +
+            "    <span style=\"font-family: Gill Sans; font-weight: bold; font-size: 50px; color: #ffffff; text-shadow: 0px 4px 4px #404040; position: relative; left: 20px\">\n"
+            +
             "        모두의 택시 \uD83D\uDE95\n" +
             "    </span>\n" +
             "</div>\n" +
             "<p class=\"p\">\n" +
-            "    <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 25px; position: relative; left: 10px\">\n" +
+            "    <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 25px; position: relative; left: 10px\">\n"
+            +
             "        모두의 택시 로그인을 위한 인증번호입니다.<br>\n" +
             "    </span>\n" +
             "    <span style=\"font-size: 10px\"><br></span>\n" +
-            "    <span style=\"font-family: Gill Sans; font-weight: normal; position: relative; left: 10px\">\n" +
+            "    <span style=\"font-family: Gill Sans; font-weight: normal; position: relative; left: 10px\">\n"
+            +
             "        아래 인증번호를 확인하여 로그인을 진행해 주세요.\n" +
             "    </span>\n" +
             "</p>\n" +
             "<div style=\"position: relative; left: 10px; width: 500px\">\n" +
             "    <hr>\n" +
             "    <div>\n" +
-            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n" +
+            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n"
+            +
             "            이메일 계정\n" +
-            "            <span style=\"color: #3ed0ac; text-decoration: underline; text-decoration-thickness: 2px; position: relative; left: 1ch\">\n" +
+            "            <span style=\"color: #3ed0ac; text-decoration: underline; text-decoration-thickness: 2px; position: relative; left: 1ch\">\n"
+            +
             "                " + email + "\n" +
             "            </span>\n" +
             "        </span>\n" +
             "    </div>\n" +
             "    <br>\n" +
             "    <div>\n" +
-            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n" +
+            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n"
+            +
             "            인증번호\n" +
             "            <span style=\"font-weight: normal; position: relative; left: 3ch\">\n" +
             "                " + certCode + "\n" +
@@ -48,7 +57,73 @@ public class MailTemplate {
             "        <br>\n" +
             "        본 메일은 발신전용입니다.<br>\n" +
             "        모두의 택시 이메일 인증 관련하여 궁금한 점이 있으시면\n" +
-            "        <a href=\"mailto:ghfkddl706@me.com?subject=모두의 택시 이메일 인증 관련 문의\" style=\"font-weight: bold\">\n" +
+            "        <a href=\"mailto:ghfkddl706@me.com?subject=모두의 택시 이메일 인증 관련 문의\" style=\"font-weight: bold\">\n"
+            +
+            "            카카오채널\n" +
+            "        </a>\n" +
+            "        로 문의 해주세요.\n" +
+            "    </span>\n" +
+            "</p>\n" +
+            "</body>\n" +
+            "</html>";
+    }
+
+    public static String getTemporaryBlockMemberMailContent(String email) {
+        return "<!DOCTYPE html>\n" +
+            "<html>\n" +
+            "<head>\n" +
+            "    <meta charset=\"UTF-8\">\n" +
+            "</head>\n" +
+            "<body>\n" +
+            "<div style=\"background-color: #3ed0ac; height: 150px; display: flex; align-items: center;\">\n"
+            +
+            "    <span style=\"font-family: Gill Sans; font-weight: bold; font-size: 50px; color: #ffffff; text-shadow: 0px 4px 4px #404040; position: relative; left: 20px\">\n"
+            +
+            "        모두의 택시 \uD83D\uDE95\n" +
+            "    </span>\n" +
+            "</div>\n" +
+            "<p class=\"p\">\n" +
+            "    <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 25px; position: relative; left: 10px\">\n"
+            +
+            "        모두의 택시 계정이 임시 차단되었습니다.<br>\n" +
+            "    </span>\n" +
+            "    <span style=\"font-size: 10px\"><br></span>\n" +
+            "    <span style=\"font-family: Gill Sans; font-weight: normal; position: relative; left: 10px\">\n"
+            +
+            "        신고 누적으로 인해 귀하의 계정이 임시 차단되었습니다. 임시 차단이 해제되기 전까지 서비스를 이용하실 수 없습니다.\n" +
+            "    </span>\n" +
+            "</p>\n" +
+            "<div style=\"position: relative; left: 10px; width: 500px\">\n" +
+            "    <hr>\n" +
+            "    <div>\n" +
+            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n"
+            +
+            "            이메일 계정\n" +
+            "            <span style=\"color: #3ed0ac; text-decoration: underline; text-decoration-thickness: 2px; position: relative; left: 1ch\">\n"
+            +
+            "                " + email + "\n" +
+            "            </span>\n" +
+            "        </span>\n" +
+            "    </div>\n" +
+            "    <br>\n" +
+            "    <div>\n" +
+            "        <span style=\"font-family: Gill Sans; font-weight: bolder; font-size: 15px;\">\n"
+            +
+            "            신고 누적\n" +
+            "            <span style=\"font-weight: normal; position: relative; left: 3ch\">\n" +
+            "                " + REPORT_STANDARD + " 회 \n" +
+            "            </span>\n" +
+            "        </span>\n" +
+            "    </div>\n" +
+            "    <hr>\n" +
+            "</div>\n" +
+            "<p style=\"position: relative; left: 10px;\">\n" +
+            "    <span style=\"font-family: Gill Sans; font-weight: normal;\">\n" +
+            "        <br>\n" +
+            "        본 메일은 발신전용입니다.<br>\n" +
+            "        모두의 택시 계정 임시 차단에 관련한 자세한 사항은\n" +
+            "        <a href=\"mailto:ghfkddl706@me.com?subject=모두의 택시 이메일 인증 관련 문의\" style=\"font-weight: bold\">\n"
+            +
             "            카카오채널\n" +
             "        </a>\n" +
             "        로 문의 해주세요.\n" +

--- a/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
@@ -54,7 +54,28 @@ public class RegisterMemberController {
     /**
      * [POST] 소셜 로그인 /{type}/login
      */
-    @Operation(summary = "소셜 로그인")
+    @Operation(
+        summary = "소셜 로그인",
+        description = "type: KAKAO, APPLE<br>"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "409", description = "로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
+            @ExampleObject(name = "MEMBER_001", description = "존재하지 않는 사용자", value = """
+                {
+                    "errorCode": "MEMBER_001",
+                    "message": "존재하지 않는 사용자입니다."
+                }
+                """),
+        })),
+        @ApiResponse(responseCode = "409", description = "로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
+            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
+                {
+                    "errorCode": "MEMBER_010",
+                    "message": "임시 차단된 사용자입니다."
+                }
+                """),
+        })),
+    })
     @PostMapping("/{type}/login")
     public ResponseEntity<TokenAndMemberResponse> login(
         @PathVariable(name = "type") SocialLoginType type,

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -46,6 +46,16 @@ public class UpdateMemberController {
         description = "Header에 refreshToken을 넣어보내주세요.<br>" +
             "key: refreshToken, value: ${refreshToken}."
     )
+    @ApiResponses({
+        @ApiResponse(responseCode = "409", description = "로그인 토큰 갱신 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
+            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
+                {
+                    "errorCode": "MEMBER_010",
+                    "message": "임시 차단된 사용자입니다."
+                }
+                """),
+        })),
+    })
     @PatchMapping("/refresh")
     public ResponseEntity<TokenAndMemberResponse> refreshLogin(
         @CurrentMember Member member) {

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -64,6 +64,9 @@ public class Member extends BaseTime {
     private int reportCount = 0;
     @NotNull
     @Builder.Default
+    private boolean blocked = false;
+    @NotNull
+    @Builder.Default
     private boolean status = true;
 
     public void certificateEmail(String email) {
@@ -96,8 +99,8 @@ public class Member extends BaseTime {
         this.reportCount++;
     }
 
-    public void setStatusFalse() {
-        this.status = false;
+    public void setBlockedTrue() {
+        this.blocked = true;
     }
 
 }

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -92,4 +92,8 @@ public class Member extends BaseTime {
         return this.nickname != null;
     }
 
+    public void plusOneReportCount() {
+        this.reportCount++;
+    }
+
 }

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -96,4 +96,8 @@ public class Member extends BaseTime {
         this.reportCount++;
     }
 
+    public void setStatusFalse() {
+        this.status = false;
+    }
+
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/RegisterMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/RegisterMemberService.java
@@ -75,6 +75,9 @@ public class RegisterMemberService {
         String snsId = getSnsIdByAccessToken(type, accessToken);
         Member member = memberRepository.findBySnsIdAndStatusTrue(snsId)
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+        if (member.isBlocked()) {
+            throw new BaseException(MemberErrorCode.BLOCKED_MEMBER);
+        }
         // FCM 토큰 저장
         saveFcmToken(member.getId(), fcmToken);
         return generateMemberToken(member);

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -36,6 +36,9 @@ public class UpdateMemberService {
 
     //TODO: Member Profile에 필요한 정보가 확정나면 다시 수정이 필요합니다.
     public TokenAndMemberResponse refreshAccessToken(Member member) {
+        if (member.isBlocked()) {
+            throw new BaseException(MemberErrorCode.BLOCKED_MEMBER);
+        }
         return new TokenAndMemberResponse(
             jwtTokenProvider.generateToken(member.getId()),
             MemberMapper.toDto(member)

--- a/src/main/java/com/modutaxi/api/domain/report/controller/RegisterReportController.java
+++ b/src/main/java/com/modutaxi/api/domain/report/controller/RegisterReportController.java
@@ -33,8 +33,16 @@ public class RegisterReportController {
      */
     @Operation(
         summary = "신고하기",
-        description = "신고 API 입니다.<br>" +
-            "헤더에 반드시 Authorization 으로 accessToken 값을 넣어주세요!"
+        description = "현재는 Member 신고만 가능합니다. targetId에 memberId를 넣어주세요. <br>" +
+            "헤더에 반드시 Authorization 으로 accessToken 값을 넣어주세요! <br>" +
+            "아래는 ReportType 입니다. ReportRequest 스케마에서도 확인 가능합니다!<br>" +
+            "<ul> <li>LEAVE_CHATROOM(중간에 채팅방을 나갔어요)</li>" +
+            "<li>LATE(제 시간에 도착하지 않았어요)</li>" +
+            "<li>FIRST_GONE(먼저 출발했어요)</li>" +
+            "<li>OUT_OF_TOUCH(연락이 되지 않아요)</li>" +
+            "<li>UNEXPECTED_ACCOUNTS(정산 금액이 예상과 달라요)</li>" +
+            "<li>NON_REMIT(정산 금액을 보내주지 않았어요)</li>" +
+            "<li>NON_REMIT(기타 (직접 입력할게요))</li> </ul>"
     )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "신고 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReportResponse.class))),

--- a/src/main/java/com/modutaxi/api/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,22 @@
+package com.modutaxi.api.domain.report.dto;
+
+import com.modutaxi.api.domain.report.entity.ReportType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ReportRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportRequest {
+        @Schema(example = "2", description = "신고 대상의 Id")
+        private Long targetId;
+        @Schema(example = "LATE", description = "신고 유형")
+        private ReportType type;
+        @Schema(example = "이 사람 제 시간 보다 너무 늦었어요..", description = "신고 내용")
+        private String content;
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/report/dto/ReportResponseDto.java
@@ -1,0 +1,17 @@
+package com.modutaxi.api.domain.report.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ReportResponseDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ReportResponse {
+        @Schema(example = "1", description = "신고 Id")
+        private Long reportId;
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/report/entity/Report.java
+++ b/src/main/java/com/modutaxi/api/domain/report/entity/Report.java
@@ -1,0 +1,38 @@
+package com.modutaxi.api.domain.report.entity;
+
+import com.modutaxi.api.common.entity.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private ReportType type;
+
+    @NotNull
+    private Long reporterId;
+
+    @NotNull
+    private Long targetId;
+
+    @NotNull
+    private String content;
+}
+

--- a/src/main/java/com/modutaxi/api/domain/report/entity/ReportType.java
+++ b/src/main/java/com/modutaxi/api/domain/report/entity/ReportType.java
@@ -1,0 +1,19 @@
+package com.modutaxi.api.domain.report.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReportType {
+
+    LEAVE_CHATROOM("중간에 채팅방을 나갔어요"),
+    LATE("제 시간에 도착하지 않았어요"),
+    FIRST_GONE("먼저 출발했어요"),
+    OUT_OF_TOUCH("연락이 되지 않아요"),
+    UNEXPECTED_ACCOUNTS("정산 금액이 예상과 달라요"),
+    NOT_REMIT("정산 금액을 보내주지 않았어요"),
+    ETC("기타 (직접 입력할게요)");
+
+    public final String message;
+}

--- a/src/main/java/com/modutaxi/api/domain/report/mapper/ReportMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/report/mapper/ReportMapper.java
@@ -1,0 +1,18 @@
+package com.modutaxi.api.domain.report.mapper;
+
+import com.modutaxi.api.domain.report.entity.Report;
+import com.modutaxi.api.domain.report.entity.ReportType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReportMapper {
+
+    public static Report toEntity(Long reporterId, Long targetId, ReportType type, String content) {
+        return Report.builder()
+            .reporterId(reporterId)
+            .targetId(targetId)
+            .type(type)
+            .content(content)
+            .build();
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
@@ -2,6 +2,7 @@ package com.modutaxi.api.domain.report.repository;
 
 import com.modutaxi.api.domain.report.entity.Report;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -20,4 +21,14 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         @Param("reporterId") Long reporterId,
         @Param("targetId") Long targetId);
 
+
+    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END "
+        + "FROM Report r "
+        + "WHERE r.createdAt > :dateTime "
+        + "AND r.reporterId = :reporterId "
+        + "AND r.targetId = :targetId")
+    boolean existsByCreatedAtAfter24AndReportedIdAndTargetId(
+        @Param("dateTime") LocalDateTime dateTime,
+        @Param("reporterId") Long reporterId,
+        @Param("targetId") Long targetId);
 }

--- a/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
@@ -1,0 +1,23 @@
+package com.modutaxi.api.domain.report.repository;
+
+import com.modutaxi.api.domain.report.entity.Report;
+import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    /**
+     * 오늘 날짜에 reporte
+     */
+    @Query(value = "SELECT CASE WHEN COUNT(r) > 0 THEN TRUE ELSE FALSE END "
+        + "FROM Report r "
+        + "WHERE date_format(r.createdAt, '%Y-%m-%d') = :date "
+        + "AND r.reporterId = :reporterId "
+        + "AND r.targetId = :targetId")
+    boolean existsByCreatedAtAndReportedIdAndTargetId(
+        @Param("date") String date,
+        @Param("reporterId") Long reporterId,
+        @Param("targetId") Long targetId);
+
+}

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -1,0 +1,63 @@
+package com.modutaxi.api.domain.report.service;
+
+import static com.modutaxi.api.common.constants.ServerConstants.REPORT_STANDARD;
+import static com.modutaxi.api.domain.report.mapper.ReportMapper.toEntity;
+
+import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
+import com.modutaxi.api.common.exception.errorcode.ReportErrorCode;
+import com.modutaxi.api.domain.member.entity.Member;
+import com.modutaxi.api.domain.member.repository.MemberRepository;
+import com.modutaxi.api.domain.report.dto.ReportResponseDto.ReportResponse;
+import com.modutaxi.api.domain.report.entity.Report;
+import com.modutaxi.api.domain.report.entity.ReportType;
+import com.modutaxi.api.domain.report.repository.ReportRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterReportService {
+
+    private final MemberRepository memberRepository;
+    private final ReportRepository reportRepository;
+
+    public ReportResponse register(Long reporterId, Long targetId, ReportType type,
+        String content) {
+        Member targetMember = memberRepository.findByIdAndStatusTrue(targetId)
+            .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+
+        validateContentLength(content);
+
+        Report report = toEntity(reporterId, targetId, type, content);
+        reportRepository.save(report);
+
+        // 같은 날, 같은 멤버가, 같은 멤버를 신고 했다면 카운팅하지 않습니다.
+        if (!existsTodayDuplicateReport(reporterId, targetId)) {
+            targetMember.plusOneReportCount();
+        }
+
+        if (targetMember.getReportCount() >= REPORT_STANDARD) {
+            // TODO: 신고가 기준 치 이상 누적되었을 때, 임시 비활성화 처리 및 슬랙 메시지 전송 로직 추가
+            // TODO: 비활성화 처리 이메일 전송 필요하다면 로직 추가
+        }
+
+        return new ReportResponse(report.getId());
+    }
+
+    private void validateContentLength(String content) {
+        if (content.length() < 10) {
+            throw new BaseException(ReportErrorCode.SHORT_CONTENT);
+        }
+    }
+
+    /**
+     * 오늘, 같은 멤버를 신고한 이력이 있는지 확인하여 boolean을 반환합니다.
+     */
+    private boolean existsTodayDuplicateReport(Long reporterId, Long targetId) {
+        String date = String.valueOf(LocalDate.now());
+        return reportRepository.existsByCreatedAtAndReportedIdAndTargetId(
+            date, reporterId, targetId);
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -77,7 +77,7 @@ public class RegisterReportService {
     private void checkExceededReportStandard(Member member) {
         if (member.getReportCount() >= REPORT_STANDARD && member.isStatus()) {
             // 임시 비활성화 처리
-            member.setStatusFalse();
+            member.setBlockedTrue();
             // 관리자 슬랙에 메시지 전송
             slackService.sendTemporaryBlockMemberMessage(member);
             // 이메일 존재하면 비활성화 처리 이메일 전송

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -7,23 +7,27 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.common.exception.errorcode.ReportErrorCode;
 import com.modutaxi.api.common.slack.SlackService;
+import com.modutaxi.api.domain.mail.service.MailServiceImpl;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.repository.MemberRepository;
 import com.modutaxi.api.domain.report.dto.ReportResponseDto.ReportResponse;
 import com.modutaxi.api.domain.report.entity.Report;
 import com.modutaxi.api.domain.report.entity.ReportType;
 import com.modutaxi.api.domain.report.repository.ReportRepository;
-import java.time.LocalDate;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class RegisterReportService {
 
     private final MemberRepository memberRepository;
     private final ReportRepository reportRepository;
     private final SlackService slackService;
+    private final MailServiceImpl mailService;
 
     public ReportResponse register(Long reporterId, Long targetId, ReportType type,
         String content) {
@@ -32,18 +36,18 @@ public class RegisterReportService {
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
         validateContentLength(content);
 
+        // 같은 날, 같은 멤버가, 같은 멤버를 신고한게 아니라면
+        if (!existsTodayDuplicateReport(reporterId, targetId)) {
+            // 신고 횟수 카운팅
+            targetMember.plusOneReportCount();
+        }
+
         // 저장
         Report report = toEntity(reporterId, targetId, type, content);
         reportRepository.save(report);
 
         // 관리자 슬랙에 메시지 전송
         slackService.sendReportMessage(report);
-
-        // 같은 날, 같은 멤버가, 같은 멤버를 신고한게 아니라면
-        if (!existsTodayDuplicateReport(reporterId, targetId)) {
-            // 신고 횟수 카운팅
-            targetMember.plusOneReportCount();
-        }
 
         // 신고 누적 체크 및 대응
         checkExceededReportStandard(targetMember);
@@ -58,24 +62,28 @@ public class RegisterReportService {
     }
 
     /**
-     * 오늘, 같은 멤버를 신고한 이력이 있는지 확인하여 boolean을 반환합니다.
+     * 24시간 이내, 같은 멤버를 신고한 이력이 있는지 확인하여 boolean을 반환합니다.
      */
     private boolean existsTodayDuplicateReport(Long reporterId, Long targetId) {
-        String date = String.valueOf(LocalDate.now());
-        return reportRepository.existsByCreatedAtAndReportedIdAndTargetId(
-            date, reporterId, targetId);
+        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
+        return reportRepository.existsByCreatedAtAfter24AndReportedIdAndTargetId(
+            twentyFourHoursAgo, reporterId, targetId);
+
     }
 
     /**
      * 해당 멤버에 대한 신고가 기준치 이상 누적되었다면 임시 비활성화 처리 후, 관리자 슬랙에 메시지를 전송합니다.
      */
     private void checkExceededReportStandard(Member member) {
-        if (member.getReportCount() >= REPORT_STANDARD) {
+        if (member.getReportCount() >= REPORT_STANDARD && member.isStatus()) {
             // 임시 비활성화 처리
             member.setStatusFalse();
             // 관리자 슬랙에 메시지 전송
             slackService.sendTemporaryBlockMemberMessage(member);
-            // TODO: 비활성화 처리 이메일 전송 필요하다면 로직 추가
+            // 이메일 존재하면 비활성화 처리 이메일 전송
+            if (member.getEmail() != null) {
+                mailService.sendTemporaryBlockMemberMail(member.getEmail());
+            }
         }
     }
 


### PR DESCRIPTION
## 요약 🎀

- 신고하기 API
- 신고/임시 차단 사용자 발생 시 슬랙에 메시지 전송 구현

## 상세 내용 🌈

- 신고하기 API
  - 같은 멤버가 같은 멤버를 여러번 신고 시 → 하루에 1번만 카운팅되고, DB에는 들어가요!
  - 나 자신은 신고할 수 없습니다!
  - 현재 신고 누적 횟수 기준은 5회이며, 5회 신고가 쌓이면 멤버가 임시 차단됩니다. 멤버 엔티티에 `blocked` 라는 필드를 추가했어요! 멤버가 임시 차단되면 로그인/리프레시 API에서 임시 차단 되었다는 Exception이 내려가게 됩니다.
- 신고/임시 차단 사용자 발생 시 슬랙에 메시지 전송 구현
  - 신고가 발생하면 이렇게 슬랙에 전송됩니다
     ![ㅇ](https://github.com/MODU-TAXI/server-api/assets/71329329/ec492cbc-1032-424b-afbd-eaf96768c1d4)
  - 사용자가 임시 차단되면 (이메일을 등록한 사용자만이라도... 아까워서요...), 이렇게 이메일을 보내요. 이메일이 없는 사용자는 어떻게 하냐구요? 로그인 시도 시 차단되었다는 모달을 통해 본인이 임시 차단되었다는 것을 확인할 수 있습니다. (프론트, PM과 합의된 부분!)
     ![1](https://github.com/MODU-TAXI/server-api/assets/71329329/22d35ad0-83ba-4ea5-b978-305f83014778)

## 질문 및 이외 사항 🚩

- 서버에 Error 발생했을 때도 슬랙에 메세지 가도록 할 수 있을 것 같은데 해볼까유?

## 리뷰어에게 ✨

- 궁금한 점 있으시다면 남겨주세용
