### PR TITLE
[MS-149] dynamic scheduler 적용

### DIFF
--- a/src/main/java/com/modutaxi/api/common/config/SchedulerConfig.java
+++ b/src/main/java/com/modutaxi/api/common/config/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.modutaxi.api.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    private static final int POOL_SIZE = 3;
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler(){
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(POOL_SIZE);
+        scheduler.setThreadNamePrefix("My Scheduler - ");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/java/com/modutaxi/api/common/config/websocket/StompHandler.java
+++ b/src/main/java/com/modutaxi/api/common/config/websocket/StompHandler.java
@@ -2,9 +2,7 @@ package com.modutaxi.api.common.config.websocket;
 
 import com.modutaxi.api.common.auth.jwt.JwtTokenProvider;
 
-import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.StompException;
-import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.common.exception.errorcode.StompErrorCode;
 import com.modutaxi.api.common.fcm.FcmService;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
@@ -73,7 +71,7 @@ public class StompHandler implements ChannelInterceptor {
 
             String memberId = redisChatRoomRepositoryImpl.findMemberBySessionId(sessionId);
             Member member = memberRepository.findById(Long.valueOf(memberId)).orElseThrow(
-                    () -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
+                    () -> new StompException(StompErrorCode.EMPTY_MEMBER));
 
             ChatRoomMappingInfo chatRoomMappingInfo = redisChatRoomRepositoryImpl.findChatInfoByMemberId(memberId);
 
@@ -96,12 +94,12 @@ public class StompHandler implements ChannelInterceptor {
                 throw new StompException(StompErrorCode.ALREADY_ROOM_IN);
             }
 
-            String nickName = member.getNickname();
-
             if (room.getCurrentHeadcount() >= FULL_MEMBER) {
                 log.error("참여하려고 하는 {}방의 인원수가 4명으로 만석입니다. 따라서 방에 참가할 수 없습니다.", roomId);
                 throw new StompException(StompErrorCode.FULL_CHAT_ROOM);
             }
+
+            String nickName = member.getNickname();
 
             if (chatRoomMappingInfo == null) {
                 chatRoomMappingInfo = new ChatRoomMappingInfo(roomId, nickName);

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/StompErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/StompErrorCode.java
@@ -12,6 +12,7 @@ public enum StompErrorCode implements SocketErrorCode {
     ALREADY_ROOM_IN("SOCKET_004"),
     FAULT_JWT("SOCKET_005"),
     FAIL_SEND_MESSAGE("SOCKET_006"),
+    EMPTY_MEMBER("SOCKET_007")
     ;
     private final String ErrorCode;
 

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/StompErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/StompErrorCode.java
@@ -11,6 +11,7 @@ public enum StompErrorCode implements SocketErrorCode {
     FAULT_ROOM_ID("SOCKET_003"),
     ALREADY_ROOM_IN("SOCKET_004"),
     FAULT_JWT("SOCKET_005"),
+    FAIL_SEND_MESSAGE("SOCKET_006"),
     ;
     private final String ErrorCode;
 

--- a/src/main/java/com/modutaxi/api/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/modutaxi/api/domain/chat/controller/ChatController.java
@@ -2,20 +2,14 @@ package com.modutaxi.api.domain.chat.controller;
 
 import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.common.auth.jwt.JwtTokenProvider;
-import com.modutaxi.api.common.exception.BaseException;
-import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
 import com.modutaxi.api.domain.chat.dto.ChatResponseDto.ChatMappingResponse;
 import com.modutaxi.api.domain.chat.dto.ChatResponseDto.DeleteResponse;
 import com.modutaxi.api.domain.chat.dto.ChatResponseDto.EnterableResponse;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
-import com.modutaxi.api.domain.chatmessage.mapper.ChatMessageMapper;
-import com.modutaxi.api.domain.chatmessage.repository.ChatMessageRepository;
 import com.modutaxi.api.domain.chat.ChatRoomMappingInfo;
 import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
 import com.modutaxi.api.domain.chat.service.ChatService;
 import com.modutaxi.api.domain.member.entity.Member;
-import com.modutaxi.api.domain.room.entity.Room;
-import com.modutaxi.api.domain.room.repository.RoomRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +30,7 @@ public class ChatController {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisChatRoomRepositoryImpl redisChatRoomRepositoryImpl;
-    private final RoomRepository roomRepository;
     private final ChatService chatService;
-    private final ChatMessageRepository chatMessageRepository;
 
 
     // /pub/chat 으로 오는 메세지 핸들링
@@ -55,13 +47,6 @@ public class ChatController {
 
         // Websocket에 발행된 메시지를 redis로 발행(publish)
         chatService.sendChatMessage(message);
-
-        // TODO: 5/2/24 mongoDB로 변경해야함 -> 시간 비교해서 리팩터링
-        Room room = roomRepository.findById(Long.valueOf(chatRoomMappingInfo.getRoomId()))
-                .orElseThrow(() -> new BaseException(RoomErrorCode.EMPTY_ROOM));
-
-        //메세지 리퍼지토리에 저장
-        chatMessageRepository.save(ChatMessageMapper.toEntity(message, room));
     }
 
     @Operation(summary = "해당 모집방에 참여 가능한 지")

--- a/src/main/java/com/modutaxi/api/domain/chat/service/ChatSchedulerService.java
+++ b/src/main/java/com/modutaxi/api/domain/chat/service/ChatSchedulerService.java
@@ -4,8 +4,6 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chatmessage.entity.MessageType;
-import com.modutaxi.api.domain.chatmessage.mapper.ChatMessageMapper;
-import com.modutaxi.api.domain.chatmessage.repository.ChatMessageRepository;
 import com.modutaxi.api.domain.room.entity.Room;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
 import lombok.AllArgsConstructor;
@@ -24,9 +22,6 @@ public class ChatSchedulerService {
 
     private final TaskScheduler taskScheduler;
     private final ChatService chatService;
-
-    // TODO: 6/4/24 전체적으로 메세지 저장로직을 전송 로직과 묶기
-    private final ChatMessageRepository chatMessageRepository;
     private final RoomRepository roomRepository;
 
     private static final long BEFORE_FIVE_MINUTES = 300;
@@ -39,7 +34,6 @@ public class ChatSchedulerService {
                 Long.valueOf(roomId), MessageType.CHAT_BOT, content,
                 "모두의택시", room.getRoomManager().getId().toString(), LocalDateTime.now());
             chatService.sendChatMessage(message);
-            chatMessageRepository.save(ChatMessageMapper.toEntity(message, room));
             log.info("{}: {}", content, Thread.currentThread().getName());
         };
     }

--- a/src/main/java/com/modutaxi/api/domain/chat/service/ChatSchedulerService.java
+++ b/src/main/java/com/modutaxi/api/domain/chat/service/ChatSchedulerService.java
@@ -1,0 +1,75 @@
+package com.modutaxi.api.domain.chat.service;
+
+import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
+import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
+import com.modutaxi.api.domain.chatmessage.entity.MessageType;
+import com.modutaxi.api.domain.chatmessage.mapper.ChatMessageMapper;
+import com.modutaxi.api.domain.chatmessage.repository.ChatMessageRepository;
+import com.modutaxi.api.domain.room.entity.Room;
+import com.modutaxi.api.domain.room.repository.RoomRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Slf4j
+@Service
+public class ChatSchedulerService {
+
+    private final TaskScheduler taskScheduler;
+    private final ChatService chatService;
+
+    // TODO: 6/4/24 전체적으로 메세지 저장로직을 전송 로직과 묶기
+    private final ChatMessageRepository chatMessageRepository;
+    private final RoomRepository roomRepository;
+
+    private static final long FIVE_MINUTES = 300;
+
+    private Runnable matchingModal(Long roomId) {
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new BaseException(RoomErrorCode.EMPTY_ROOM));
+        return () -> {
+            ChatMessageRequestDto message = new ChatMessageRequestDto(
+                    Long.valueOf(roomId), MessageType.CHAT_BOT, "매칭완료 하시겠습니까?",
+                    "모두의택시", room.getRoomManager().getId().toString(), LocalDateTime.now());
+            chatService.sendChatMessage(message);
+            chatMessageRepository.save(ChatMessageMapper.toEntity(message, room));
+            log.info("매칭완료 알림이 실행되었습니다: {}", Thread.currentThread().getName());
+        };
+    }
+
+    private Runnable callTaxi(Long roomId) {
+        Room room = roomRepository.findById(roomId).orElseThrow(() -> new BaseException(RoomErrorCode.EMPTY_ROOM));
+        return () -> {
+            ChatMessageRequestDto message = new ChatMessageRequestDto(
+                    Long.valueOf(roomId), MessageType.CHAT_BOT, "택시 부르러 가볼까요?",
+                    "모두의택시", room.getRoomManager().getId().toString(), LocalDateTime.now());
+            chatService.sendChatMessage(message);
+            chatMessageRepository.save(ChatMessageMapper.toEntity(message, room));
+            log.info("5분전 알림이 실행되었습니다: {}", Thread.currentThread().getName());
+        };
+    }
+
+
+    public void addTask(Long roomId, LocalDateTime departureTime) {
+        //매칭완료 알림 전송
+        long delaySeconds = calculateDelaySeconds(LocalDateTime.now(), departureTime);
+
+        Runnable matchingModal = matchingModal(roomId);
+        taskScheduler.schedule(matchingModal, Instant.now().plusSeconds(delaySeconds));
+
+        Runnable callTaxiTask = callTaxi(roomId);
+        delaySeconds = delaySeconds > FIVE_MINUTES + 20 ? delaySeconds - FIVE_MINUTES : 0;
+        taskScheduler.schedule(callTaxiTask, Instant.now().plusSeconds(delaySeconds));
+    }
+
+    private long calculateDelaySeconds(LocalDateTime now, LocalDateTime targetDateTime) {
+        Duration duration = Duration.between(now, targetDateTime);
+        return Math.max(0, duration.getSeconds());
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/chat/service/ChatService.java
+++ b/src/main/java/com/modutaxi/api/domain/chat/service/ChatService.java
@@ -12,6 +12,7 @@ import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chat.ChatRoomMappingInfo;
 import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
 import com.modutaxi.api.domain.chatmessage.mapper.ChatMessageMapper;
+import com.modutaxi.api.domain.chatmessage.repository.ChatMessageRepository;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.entity.Room;
 import com.modutaxi.api.domain.room.repository.RoomRepository;
@@ -31,6 +32,7 @@ public class ChatService {
     private final RedisChatRoomRepositoryImpl redisChatRoomRepositoryImpl;
     private final RoomRepository roomRepository;
     private final FcmService fcmService;
+    private final ChatMessageRepository chatMessageRepository;
 
     /**
      * 채팅방에 메시지 pub
@@ -40,6 +42,8 @@ public class ChatService {
                 ChatMessageMapper.toDto(chatMessageRequestDto));
 
         fcmService.sendChatMessage(chatMessageRequestDto);
+
+        chatMessageRepository.save(ChatMessageMapper.toEntity(chatMessageRequestDto));
     }
 
     /**

--- a/src/main/java/com/modutaxi/api/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/com/modutaxi/api/domain/chat/service/RedisSubscriber.java
@@ -2,6 +2,8 @@ package com.modutaxi.api.domain.chat.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.modutaxi.api.common.exception.StompException;
+import com.modutaxi.api.common.exception.errorcode.StompErrorCode;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageResponseDto.ChatMessageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -21,7 +23,7 @@ public class RedisSubscriber {
             messageSendingOperations.convertAndSend("/sub/chat/" + chatMessageResponse.getRoomId(),
                     chatMessageResponse);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("메세지 전송에 실패하였습니다.");
+            throw new StompException(StompErrorCode.FAIL_SEND_MESSAGE);
         }
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/chatmessage/entity/ChatMessage.java
+++ b/src/main/java/com/modutaxi/api/domain/chatmessage/entity/ChatMessage.java
@@ -5,6 +5,8 @@ import com.modutaxi.api.domain.room.entity.Room;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
+
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,17 +22,26 @@ public class ChatMessage extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageId;
 
-    @ManyToOne
-    @JoinColumn(name = "room_id")
-    private Room room;
+    @NotNull
+    private Long roomId;
 
-    private MessageType messageType;
+    @NotNull
+    @Builder.Default
+    private MessageType messageType  = MessageType.CHAT;
 
-    private String content;
+    @NotNull
+    @Builder.Default
+    private String content = "";
 
-    private String sender;
+    @NotNull
+    @Builder.Default
+    private String sender = "모두의택시";
 
-    private String memberId;
+    @NotNull
+    @Builder.Default
+    private String memberId = "1";
 
-    private LocalDateTime dateTime;
+    @NotNull
+    @Builder.Default
+    private LocalDateTime dateTime = LocalDateTime.now();
 }

--- a/src/main/java/com/modutaxi/api/domain/chatmessage/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/chatmessage/mapper/ChatMessageMapper.java
@@ -3,13 +3,12 @@ package com.modutaxi.api.domain.chatmessage.mapper;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageResponseDto.ChatMessageResponse;
 import com.modutaxi.api.domain.chatmessage.entity.ChatMessage;
-import com.modutaxi.api.domain.room.entity.Room;
 
 public class ChatMessageMapper {
 
-    public static ChatMessage toEntity(ChatMessageRequestDto messageRequestDto, Room room){
+    public static ChatMessage toEntity(ChatMessageRequestDto messageRequestDto){
         return ChatMessage.builder()
-                .room(room)
+                .roomId(messageRequestDto.getRoomId())
                 .messageType(messageRequestDto.getType())
                 .content(messageRequestDto.getContent())
                 .sender(messageRequestDto.getSender())
@@ -20,7 +19,7 @@ public class ChatMessageMapper {
 
     public static ChatMessageResponse toDto(ChatMessage chatMessage) {
         return ChatMessageResponse.builder()
-            .roomId(chatMessage.getRoom().getId())
+            .roomId(chatMessage.getRoomId())
             .messageType(chatMessage.getMessageType())
             .content(chatMessage.getContent())
             .sender(chatMessage.getSender())

--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -23,6 +23,8 @@ public class RoomResponseDto {
         private boolean isMyRoom;
         @Schema(example = "true", description = "내가 참여해 있는 방인 지 체크")
         private boolean isParticipate;
+        @Schema(example = "true", description = "내가 참여 요청 중인 방인 지 체크")
+        private boolean isWaiting;
         @Schema(description = "택시팟 id")
         private Long roomId;
         @Schema(description = "도착 거점 id")

--- a/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
@@ -50,11 +50,13 @@ public class RoomMapper {
             .build();
     }
 
-    public static RoomDetailResponse toDto(Room room, Member member, LineString path, boolean isParticipate) {
+    public static RoomDetailResponse toDto(
+        Room room, Member member, LineString path, boolean isParticipate, boolean isWaiting) {
         return RoomDetailResponse.builder()
             .managerId(room.getRoomManager().getId())
             .isMyRoom(room.getRoomManager().getId().equals(member.getId()))
             .isParticipate(isParticipate)
+            .isWaiting(isWaiting)
             .roomId(room.getId())
             .spotId(room.getSpot().getId())
             .departureDairyDate(TimeFormatConverter.convertTimeToDiaryDate(room.getDepartureTime()))

--- a/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/GetRoomService.java
@@ -58,6 +58,7 @@ public class GetRoomService {
                 TaxiInfoErrorCode.EMPTY_TAXI_INFO)).getPath();
 
         boolean isParticipate = false;
+        boolean isWaiting = redisChatRoomRepository.findMemberInWaitingList(roomId.toString(), member.getId().toString());
 
         ChatRoomMappingInfo chatRoomMappingInfo = redisChatRoomRepository.findChatInfoByMemberId(member.getId().toString());
 
@@ -66,7 +67,7 @@ public class GetRoomService {
             isParticipate = myParticipatedRoomId.equals(roomId.toString());
         }
 
-        return RoomMapper.toDto(room, member, path, isParticipate);
+        return RoomMapper.toDto(room, member, path, isParticipate, isWaiting);
     }
 
     public PageResponseDto<List<RoomSimpleResponse>> getRoomSimpleList(int page, int size, Long spotId, List<RoomTagBitMask> tags, Point point, Long radius, Boolean isImminent, RoomSortType sortType) {

--- a/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
@@ -9,6 +9,7 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
 import com.modutaxi.api.common.exception.errorcode.SpotError;
 import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
+import com.modutaxi.api.domain.chat.service.ChatSchedulerService;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.CreateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
@@ -36,6 +37,7 @@ public class RegisterRoomService {
 
     private final GetTaxiInfoService getTaxiInfoService;
     private final RegisterTaxiInfoService registerTaxiInfoService;
+    private final ChatSchedulerService chatSchedulerService;
 
     private static final float MIN_LATITUDE = 33;
     private static final float MAX_LATITUDE = 40;
@@ -85,6 +87,8 @@ public class RegisterRoomService {
         roomRepository.save(room);
         redisChatRoomRepositoryImpl.addRoomInMemberList(room.getId().toString(), member.getId().toString());
         registerTaxiInfoService.savePath(room.getId(), path);
+
+        chatSchedulerService.addTask(room.getId(), room.getDepartureTime());
         return RoomMapper.toDto(room, member, path, true);
     }
 

--- a/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/RegisterRoomService.java
@@ -89,7 +89,7 @@ public class RegisterRoomService {
         registerTaxiInfoService.savePath(room.getId(), path);
 
         chatSchedulerService.addTask(room.getId(), room.getDepartureTime());
-        return RoomMapper.toDto(room, member, path, true);
+        return RoomMapper.toDto(room, member, path, true, false);
     }
 
     private void createRoomRequestValidator(Member member, CreateRoomRequest createRoomRequest) {

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -11,8 +11,6 @@ import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
 import com.modutaxi.api.domain.chat.service.ChatService;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chatmessage.entity.MessageType;
-import com.modutaxi.api.domain.chatmessage.mapper.ChatMessageMapper;
-import com.modutaxi.api.domain.chatmessage.repository.ChatMessageRepository;
 import com.modutaxi.api.domain.chatmessage.service.ChatMessageService;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.repository.MemberRepository;
@@ -58,7 +56,6 @@ public class UpdateRoomService {
     private final FcmService fcmService;
     private final MemberRepository memberRepository;
     private final ChatService chatService;
-    private final ChatMessageRepository chatMessageRepository;
 
     private static final float MIN_LATITUDE = 33;
     private static final float MAX_LATITUDE = 40;
@@ -302,9 +299,6 @@ public class UpdateRoomService {
                         ,"모두의 택시 봇",room.getRoomManager().getId().toString(),LocalDateTime.now());
 
         chatService.sendChatMessage(chatMessageRequestDto);
-
-        //메세지 리퍼지토리에 저장
-        chatMessageRepository.save(ChatMessageMapper.toEntity(chatMessageRequestDto, room));
 
         return new UpdateRoomResponse(true);
     }

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -89,7 +89,7 @@ public class UpdateRoomService {
 
         room.update(newRoomData);
         fcmService.sendUpdateRoomInfo(member.getId(), roomId);
-        return RoomMapper.toDto(room, member, path, true);
+        return RoomMapper.toDto(room, member, path, true, false);
     }
 
     @Transactional

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
@@ -119,7 +119,7 @@ public class RoomWaitingService {
 
         //방 팀원들에게 참가했다는 메세지 보내기
         chatService.sendChatMessage(new ChatMessageRequestDto(
-                Long.valueOf(roomId), MessageType.JOIN, memberId + "님이 들어왔습니다.",
+                Long.valueOf(roomId), MessageType.JOIN, participant.getNickname() + "님이 들어왔습니다.",
                 chatRoomMappingInfo.getNickname(), memberId, LocalDateTime.now()));
 
         return new ApplyResponse(true);

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
@@ -109,7 +109,7 @@ public class RoomWaitingService {
         redisChatRoomRepositoryImpl.addRoomInMemberList(roomId, memberId);
 
         //매핑 정보 저장
-        ChatRoomMappingInfo chatRoomMappingInfo = new ChatRoomMappingInfo(roomId, member.getNickname());
+        ChatRoomMappingInfo chatRoomMappingInfo = new ChatRoomMappingInfo(roomId, participant.getNickname());
         redisChatRoomRepositoryImpl.setUserEnterInfo(memberId, chatRoomMappingInfo);
 
         //fcm구독

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
@@ -109,7 +109,7 @@ public class RoomWaitingService {
         redisChatRoomRepositoryImpl.addRoomInMemberList(roomId, memberId);
 
         //매핑 정보 저장
-        ChatRoomMappingInfo chatRoomMappingInfo = new ChatRoomMappingInfo(roomId, memberId);
+        ChatRoomMappingInfo chatRoomMappingInfo = new ChatRoomMappingInfo(roomId, member.getNickname());
         redisChatRoomRepositoryImpl.setUserEnterInfo(memberId, chatRoomMappingInfo);
 
         //fcm구독


### PR DESCRIPTION
## 요약 🎀
- 예약 알림 전송 기능 추가
- 채팅 메세지 외래키 제약조건 제거(Room과 제약조건 제거)
- 매니저를 제외하고 sender가 memberId로 오는 문제 해결

## 상세 내용 🌈
### 예약 알림 전송 기능 추가
**ThreadPool config 설정**
ThreadPoolTaskScheduler 빈을 등록함으로써 스케줄링 동작을 custom하였습니다.
기본적으로 쓰레드 풀 사이즈는 1입니다. 예약된 작업의 동시 실행을 위해 사용할 수 있는 스레드 수를 3으로 늘렸습니다.
setThreadNamePrefix("My Scheduler - "): 사실 스케줄 작업은 스레드를 차지하고 있기 때문에 메모리 사용률에 크게 좋다고 생각하지 않았습니다. 이에 따라 디버깅과 모니터링 목적으로 스레드 식별을 위해 이름을 지정해주었습니다.

**Runnable 객체 구현**
스케줄러에 Task를 부여하기 위해서는 Runnable객체(실행할 동작)과 Trigger(Cron식) 혹은 시작 시간을 부여해야 합니다.
만약 세번째 인자로 period를 부여하면 주기적으로 동작하지만 우리의 시스템에서는 요청이 들어오고 한번만 수행되어야 하기에 세번째 인자는 추가하지 않았고, 시작 시간만 부여하였습니다.

<img width="672" alt="스크린샷 2024-06-04 오후 2 22 25" src="https://github.com/MODU-TAXI/server-api/assets/100510247/fcbc8676-57c1-40a3-948a-554be532544b">

```java
private Runnable chatBotNotice(Long roomId, String content) {
        Room room = roomRepository.findById(roomId).orElseThrow(() -> new BaseException(RoomErrorCode.EMPTY_ROOM));
        return () -> {
            ChatMessageRequestDto message = new ChatMessageRequestDto(
                Long.valueOf(roomId), MessageType.CHAT_BOT, content,
                "모두의택시", room.getRoomManager().getId().toString(), LocalDateTime.now());
            chatService.sendChatMessage(message);
            chatMessageRepository.save(ChatMessageMapper.toEntity(message, room));
            log.info("{}: {}", content, Thread.currentThread().getName());
        };
    }
```
위와 같이 챗봇이 Redis Pub/Sub과 Fcm을 통해 메세지를 발행하고 전송하는 Task를 하나의 Runnable 객체로 반환하여 아래와 같이 부여하였습니다.

```java
Runnable matchingModal = chatBotNotice(roomId, "매칭완료 하시겠습니까?");
        taskScheduler.schedule(matchingModal, Instant.now().plusSeconds(delaySeconds));
```


## 테스트
방의 생성 시간은 00시 09분입니다.
출발 예정 시간은 00시 12분입니다.
(참고: 출발 5분 전 알림의 경우 로그에는 5분 전이라고 되어있지만 1분으로 설정해놓은 상황입니다.)
스웨거를 통해 방을 생성하였습니다.
<img width="1437" alt="요청시간" src="https://github.com/MODU-TAXI/server-api/assets/100510247/a382fcfa-7b84-4887-9510-d7577f9696aa">

아래 로그가 찍힌 화면에서 알 수 있듯이 출발 예정 시간 1분 전과 출발 예정 시간에 부여된 Task가 정상적으로 실행된 것을 볼 수 있습니다.

![성공적으로수행](https://github.com/MODU-TAXI/server-api/assets/100510247/bd965558-603f-4c89-b7cf-662f1c2374d6)
<img width="828" alt="해당room이 저장된시간" src="https://github.com/MODU-TAXI/server-api/assets/100510247/c36d1c39-5439-433c-8cf6-3f8a27de3b75">



## 리뷰어에게 ✨
**예상되는 문제 & 다음 진행할 작업**
1. 애플리케이션 서버를 재시작하면 예약된 Task들이 모두 초기화될 것으로 예상됩니다. 
- 이에 따라 서버가 종료되기 전에 Task를 어딘가 저장하고, 서버가 시작할 때 작업들을 불러와 다시 Schduler에게 할당하는 작업을 진행할 것 같습니다.
2. 서버 부하 테스트
- 테스트 환경에서는 소실되는 Task가 없었지만 대기 중인 작업만큼 쓰레드를 차지할 것이라 생각합니다. 이에 따라 메모리 사용률을 모니터링 할 필요가 있어보입니다.

**참고자료**
- https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/scheduling/TaskScheduler.html
