### PR TITLE
[MS-146] 신고하기 API 수정 사항 반영

### DIFF
--- a/src/main/java/com/modutaxi/api/common/slack/SlackService.java
+++ b/src/main/java/com/modutaxi/api/common/slack/SlackService.java
@@ -54,10 +54,11 @@ public class SlackService {
     public void sendReportMessage(Report report) {
         String title = "새로운 신고가 접수되었습니다!";
         HashMap<String, String> data = new HashMap<>();
-        data.put("0. 신고자 ID", Long.toString(report.getReporterId()));
-        data.put("1. 신고 대상자 ID", Long.toString(report.getTargetId()));
-        data.put("2. 신고 유형", report.getType().getMessage());
-        data.put("3. 신고 내용", report.getContent());
+        data.put("0. 택시팟 ID", Long.toString(report.getRoomId()));
+        data.put("1. 신고자 ID", Long.toString(report.getReporterId()));
+        data.put("2. 신고 대상자 ID", Long.toString(report.getTargetId()));
+        data.put("3. 신고 유형", report.getType().getMessage());
+        data.put("4. 신고 내용", report.getContent());
 
         sendMessage(reportSlackToken, title, data, Color.GREEN.getCode());
     }

--- a/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
@@ -67,14 +67,6 @@ public class RegisterMemberController {
                 }
                 """),
         })),
-        @ApiResponse(responseCode = "409", description = "로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
-            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
-                {
-                    "errorCode": "MEMBER_010",
-                    "message": "임시 차단된 사용자입니다."
-                }
-                """),
-        })),
     })
     @PostMapping("/{type}/login")
     public ResponseEntity<TokenAndMemberResponse> login(

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -46,16 +46,6 @@ public class UpdateMemberController {
         description = "Header에 refreshToken을 넣어보내주세요.<br>" +
             "key: refreshToken, value: ${refreshToken}."
     )
-    @ApiResponses({
-        @ApiResponse(responseCode = "409", description = "로그인 토큰 갱신 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
-            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
-                {
-                    "errorCode": "MEMBER_010",
-                    "message": "임시 차단된 사용자입니다."
-                }
-                """),
-        })),
-    })
     @PatchMapping("/refresh")
     public ResponseEntity<TokenAndMemberResponse> refreshLogin(
         @CurrentMember Member member) {

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -2,7 +2,6 @@ package com.modutaxi.api.domain.member.controller;
 
 import com.modutaxi.api.common.auth.CurrentMember;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
-import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.common.exception.errorcode.SmsErrorCode;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmMailCertificationReqeust;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.ConfirmSmsCertificationReqeust;
@@ -254,42 +253,11 @@ public class UpdateMemberController {
         summary = "멤버 프로필 변경",
         description = "멤버 프로필을 변경합니다.<br>" +
             "헤더에 반드시 Authorization 으로 accessToken 값을 넣어주세요!<br>" +
-            "등록한 프로필 사진을 삭제하고 싶다면 blank(\"\")를 보내주세요!"
+            "GENDER: MALE, FEMALE 중 1 입니다.<br>" +
+            "등록한 프로필 사진을 삭제하고 싶다면 blank(\"\")를 보내주세요!. 프로필 사진을 변경하지 않고 싶으면, 현재 프로필 사진 URL을 보내주세요."
     )
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "프로필 변경 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UpdateProfileResponse.class))),
-        @ApiResponse(responseCode = "400", description = "프로필 변경 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
-            @ExampleObject(name = "MEMBER_003", description = "닉네임 중복", value = """
-                {
-                    "errorCode": "MEMBER_003",
-                    "message": "이미 있는 닉네임이에요!"
-                }
-                """),
-            @ExampleObject(name = "MEMBER_006", description = "공백, 특수문자 포함", value = """
-                {
-                    "errorCode": "MEMBER_006",
-                    "message": "공백, 특수문자는 사용할 수 없어요!"
-                }
-                """),
-            @ExampleObject(name = "MEMBER_007", description = "닉네임 최소 길이 제한", value = """
-                {
-                    "errorCode": "MEMBER_007",
-                    "message": "닉네임은 최소 2글자부터 가능해요!"
-                }
-                """),
-            @ExampleObject(name = "MEMBER_008", description = "닉네임 최대 길이 제한", value = """
-                {
-                    "errorCode": "MEMBER_008",
-                    "message": "닉네임은 최대 12글자까지 가능해요!"
-                }
-                """),
-            @ExampleObject(name = "MEMBER_009", description = "비속어 혹은 부적절한 단어", value = """
-                {
-                    "errorCode": "MEMBER_009",
-                    "message": "비속어 혹은 부적절한 단어가 포함된 닉네임은 생성할 수 없어요!"
-                }
-                """),
-        })),
     })
     @PatchMapping("")
     public ResponseEntity<UpdateProfileResponse> updateMemberProfile(
@@ -298,6 +266,7 @@ public class UpdateMemberController {
         @RequestBody UpdateProfileRequest request
     ) {
         return ResponseEntity.ok(updateMemberService.updateProfile(
-            member, request.getNickname(), request.getImageUrl()));
+            member, request.getName(), request.getGender(), request.getPhoneNumber(),
+            request.getImageUrl()));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
@@ -77,8 +77,12 @@ public class MemberRequestDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateProfileRequest {
-        @Schema(description = "변경할 닉네임")
-        private String nickname;
+        @Schema(description = "변경할 이름")
+        private String name;
+        @Schema(description = "변경할 성별")
+        private Gender gender;
+        @Schema(description = "변경할 전화번호")
+        private String phoneNumber;
         @Schema(description = "변경할 프로필 이미지의 S3 링크")
         private String ImageUrl;
     }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -48,6 +48,7 @@ public class MemberResponseDto {
         private String phoneNumber;
         private String email;
         private String imageUrl;
+        private int matchingCount;
         private boolean blocked;
     }
 
@@ -65,6 +66,8 @@ public class MemberResponseDto {
         private Long id;
         @Schema(example = "헤일", description = "닉네임")
         private String nickname;
+        @Schema(example = "3", description = "이용 횟수")
+        private int matchingCount;
         @Schema(example = "true", description = "학생 인증 여부")
         private boolean isCertified;
         @Schema(example = "-", description = "프로필 이미지 S3 링크")

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -77,10 +77,13 @@ public class MemberResponseDto {
     @Getter
     @AllArgsConstructor
     public static class UpdateProfileResponse {
-        @Schema(example = "헤일", description = "변경 완료한 닉네임")
-        private String nickname;
-        @Schema(example = "-",
-            description = "변경 완료한 프로필 이미지 S3 링크")
-        private String imageUrl;
+        @Schema(description = "변경한 이름")
+        private String name;
+        @Schema(description = "변경한 성별")
+        private Gender gender;
+        @Schema(description = "변경한 전화번호")
+        private String phoneNumber;
+        @Schema(description = "변경한 프로필 이미지의 S3 링크")
+        private String ImageUrl;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -48,6 +48,7 @@ public class MemberResponseDto {
         private String phoneNumber;
         private String email;
         private String imageUrl;
+        private boolean blocked;
     }
 
     @Getter

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -79,8 +79,10 @@ public class Member extends BaseTime {
         this.nickname = nickname;
     }
 
-    public void updateProfile(String nickname, String imageUrl) {
-        this.nickname = nickname;
+    public void updateProfile(String name, Gender gender, String phoneNumber, String imageUrl) {
+        this.name = name;
+        this.gender = gender;
+        this.phoneNumber = phoneNumber;
         this.imageUrl = imageUrl;
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -47,6 +47,7 @@ public class Member extends BaseTime {
 
     private String imageUrl;
 
+    //TODO: 도착 확정 API에서 매칭 횟수와 노쇼 횟수 카운팅
     @NotNull
     @Builder.Default
     private int matchingCount = 0;  // 매칭 횟수

--- a/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
@@ -27,6 +27,7 @@ public class MemberMapper {
             .phoneNumber(member.getPhoneNumber())
             .email(member.getEmail())
             .imageUrl(member.getImageUrl())
+            .matchingCount(member.getMatchingCount())
             .blocked(member.isBlocked())
             .build();
     }
@@ -37,6 +38,7 @@ public class MemberMapper {
             .nickname(member.getNickname())
             .isCertified(member.isCertified())
             .imageUrl(member.getImageUrl())
+            .matchingCount(member.getMatchingCount())
             .build();
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/member/mapper/MemberMapper.java
@@ -27,6 +27,7 @@ public class MemberMapper {
             .phoneNumber(member.getPhoneNumber())
             .email(member.getEmail())
             .imageUrl(member.getImageUrl())
+            .blocked(member.isBlocked())
             .build();
     }
 

--- a/src/main/java/com/modutaxi/api/domain/member/service/RegisterMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/RegisterMemberService.java
@@ -75,9 +75,6 @@ public class RegisterMemberService {
         String snsId = getSnsIdByAccessToken(type, accessToken);
         Member member = memberRepository.findBySnsIdAndStatusTrue(snsId)
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
-        if (member.isBlocked()) {
-            throw new BaseException(MemberErrorCode.BLOCKED_MEMBER);
-        }
         // FCM 토큰 저장
         saveFcmToken(member.getId(), fcmToken);
         return generateMemberToken(member);

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -11,6 +11,7 @@ import com.modutaxi.api.domain.mail.service.MailUtil;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.CertificationResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.TokenAndMemberResponse;
 import com.modutaxi.api.domain.member.dto.MemberResponseDto.UpdateProfileResponse;
+import com.modutaxi.api.domain.member.entity.Gender;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.entity.Role;
 import com.modutaxi.api.domain.member.mapper.MemberMapper;
@@ -92,8 +93,8 @@ public class UpdateMemberService {
     }
 
     @Transactional
-    public UpdateProfileResponse updateProfile(Member member, String nickname, String imageUrl) {
-        checkNickname(nickname);
+    public UpdateProfileResponse updateProfile(Member member, String name, Gender gender,
+        String phoneNumber, String imageUrl) {
         // imageUrl == "" 로 들어오면 삭제 요청입니다.
         if (Objects.equals(imageUrl, "")) {
             if (member.existsNickname()) {   // 프로필 사진이 있었다면 s3에서 삭제
@@ -101,18 +102,10 @@ public class UpdateMemberService {
             }
             imageUrl = null;
         }
-        member.updateProfile(nickname, imageUrl);
+        member.updateProfile(name, gender, phoneNumber, imageUrl);
         memberRepository.save(member);
-        return new UpdateProfileResponse(member.getNickname(), member.getImageUrl());
-    }
-
-    private void checkNickname(String nickname) {
-        // 중복 체크
-        if (memberRepository.existsByNickname(nickname)) {
-            throw new BaseException(MemberErrorCode.DUPLICATE_NICKNAME);
-        }
-        // 그 외 필터링
-        NicknameValidator.validate(nickname);
+        return new UpdateProfileResponse(member.getName(), member.getGender(),
+            member.getPhoneNumber(), member.getImageUrl());
     }
 
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -36,9 +36,6 @@ public class UpdateMemberService {
 
     //TODO: Member Profile에 필요한 정보가 확정나면 다시 수정이 필요합니다.
     public TokenAndMemberResponse refreshAccessToken(Member member) {
-        if (member.isBlocked()) {
-            throw new BaseException(MemberErrorCode.BLOCKED_MEMBER);
-        }
         return new TokenAndMemberResponse(
             jwtTokenProvider.generateToken(member.getId()),
             MemberMapper.toDto(member)

--- a/src/main/java/com/modutaxi/api/domain/report/controller/RegisterReportController.java
+++ b/src/main/java/com/modutaxi/api/domain/report/controller/RegisterReportController.java
@@ -76,6 +76,10 @@ public class RegisterReportController {
         @RequestBody ReportRequest request
     ) {
         return ResponseEntity.ok(registerReportService.register(
-            member.getId(), request.getTargetId(), request.getType(), request.getContent()));
+            member.getId(),
+            request.getTargetId(),
+            request.getRoomId(),
+            request.getType(),
+            request.getContent()));
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/report/dto/ReportRequestDto.java
@@ -12,6 +12,8 @@ public class ReportRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ReportRequest {
+        @Schema(example = "1", description = "room Id")
+        private Long roomId;
         @Schema(example = "2", description = "신고 대상의 Id")
         private Long targetId;
         @Schema(example = "LATE", description = "신고 유형")

--- a/src/main/java/com/modutaxi/api/domain/report/entity/Report.java
+++ b/src/main/java/com/modutaxi/api/domain/report/entity/Report.java
@@ -27,6 +27,9 @@ public class Report extends BaseTime {
     private ReportType type;
 
     @NotNull
+    private Long roomId;
+
+    @NotNull
     private Long reporterId;
 
     @NotNull

--- a/src/main/java/com/modutaxi/api/domain/report/mapper/ReportMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/report/mapper/ReportMapper.java
@@ -7,10 +7,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReportMapper {
 
-    public static Report toEntity(Long reporterId, Long targetId, ReportType type, String content) {
+    public static Report toEntity(Long reporterId, Long targetId, Long roomId, ReportType type,
+        String content) {
         return Report.builder()
             .reporterId(reporterId)
             .targetId(targetId)
+            .roomId(roomId)
             .type(type)
             .content(content)
             .build();

--- a/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/report/repository/ReportRepository.java
@@ -21,14 +21,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
         @Param("reporterId") Long reporterId,
         @Param("targetId") Long targetId);
 
-
-    @Query("SELECT CASE WHEN COUNT(r) > 0 THEN true ELSE false END "
-        + "FROM Report r "
-        + "WHERE r.createdAt > :dateTime "
-        + "AND r.reporterId = :reporterId "
-        + "AND r.targetId = :targetId")
-    boolean existsByCreatedAtAfter24AndReportedIdAndTargetId(
-        @Param("dateTime") LocalDateTime dateTime,
+    boolean existsByRoomIdAndReporterIdAndTargetId(
+        @Param("roomId") Long roomId,
         @Param("reporterId") Long reporterId,
         @Param("targetId") Long targetId);
 }

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -36,8 +36,8 @@ public class RegisterReportService {
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
         validateContentLength(content);
 
-        // 같은 날, 같은 멤버가, 같은 멤버를 신고한게 아니라면
-        if (!existsTodayDuplicateReport(reporterId, targetId)) {
+        // 카운팅 조건: 같은 roomId, reporterId, targetId 가 존재하지 않는다면
+        if (!existsDuplicateReport(roomId, reporterId, targetId)) {
             // 신고 횟수 카운팅
             targetMember.plusOneReportCount();
         }
@@ -62,12 +62,11 @@ public class RegisterReportService {
     }
 
     /**
-     * 24시간 이내, 같은 멤버를 신고한 이력이 있는지 확인하여 boolean을 반환합니다.
+     * 같은 택시팟에서, 같은 멤버를 신고한 이력이 있는지 확인하여 boolean을 반환합니다.
      */
-    private boolean existsTodayDuplicateReport(Long reporterId, Long targetId) {
-        LocalDateTime twentyFourHoursAgo = LocalDateTime.now().minusHours(24);
-        return reportRepository.existsByCreatedAtAfter24AndReportedIdAndTargetId(
-            twentyFourHoursAgo, reporterId, targetId);
+    private boolean existsDuplicateReport(Long roomId, Long reporterId, Long targetId) {
+        return reportRepository.existsByRoomIdAndReporterIdAndTargetId(
+            roomId, reporterId, targetId);
 
     }
 

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -29,8 +29,8 @@ public class RegisterReportService {
     private final SlackService slackService;
     private final MailServiceImpl mailService;
 
-    public ReportResponse register(Long reporterId, Long targetId, ReportType type,
-        String content) {
+    public ReportResponse register(
+        Long reporterId, Long targetId, Long roomId, ReportType type, String content) {
         // validation
         Member targetMember = memberRepository.findByIdAndStatusTrue(targetId)
             .orElseThrow(() -> new BaseException(MemberErrorCode.EMPTY_MEMBER));
@@ -43,7 +43,7 @@ public class RegisterReportService {
         }
 
         // 저장
-        Report report = toEntity(reporterId, targetId, type, content);
+        Report report = toEntity(reporterId, targetId, roomId, type, content);
         reportRepository.save(report);
 
         // 관리자 슬랙에 메시지 전송

--- a/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
+++ b/src/main/java/com/modutaxi/api/domain/room/controller/RegisterRoomController.java
@@ -2,11 +2,17 @@ package com.modutaxi.api.domain.room.controller;
 
 
 import com.modutaxi.api.common.auth.CurrentMember;
+import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dto.RoomRequestDto.CreateRoomRequest;
 import com.modutaxi.api.domain.room.dto.RoomResponseDto.RoomDetailResponse;
 import com.modutaxi.api.domain.room.service.RegisterRoomService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +34,16 @@ public class RegisterRoomController {
      * [POST] 방 생성
      */
     @Operation(summary = "모집방 생성", description = "모집방을 생성합니다.<br>목적지 거점의 id, 방 태그, 출발지의 경도, 위도, 출발 시각, 출발지 이름, 목표 인원수를 입력 해주세요.<br>방 태그 : **ONLY_WOMAN**, **MANNER**, **STUDENT_CERTIFICATION**")
+    @ApiResponses({
+        @ApiResponse(responseCode = "409", description = "방 생성 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
+            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
+                {
+                    "errorCode": "MEMBER_010",
+                    "message": "임시 차단된 사용자입니다."
+                }
+                """),
+        })),
+    })
     @PostMapping
     public ResponseEntity<RoomDetailResponse> createRoom(
         @CurrentMember Member member,

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/controller/RoomWaitingController.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/controller/RoomWaitingController.java
@@ -1,12 +1,18 @@
 package com.modutaxi.api.domain.roomwaiting.controller;
 
 import com.modutaxi.api.common.auth.CurrentMember;
+import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.roomwaiting.mapper.RoomWaitingMapper.ApplyResponse;
 import com.modutaxi.api.domain.roomwaiting.mapper.RoomWaitingMapper.MemberRoomInResponseList;
 import com.modutaxi.api.domain.roomwaiting.mapper.RoomWaitingMapper.RoomWaitingResponseList;
 import com.modutaxi.api.domain.roomwaiting.service.RoomWaitingService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +26,16 @@ public class RoomWaitingController {
     private final RoomWaitingService roomWaitingService;
 
     @Operation(summary = "방 입장 요청")
+    @ApiResponses({
+        @ApiResponse(responseCode = "409", description = "방 입장 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
+            @ExampleObject(name = "MEMBER_010", description = "신고 누적으로 인해 임시 차단", value = """
+                {
+                    "errorCode": "MEMBER_010",
+                    "message": "임시 차단된 사용자입니다."
+                }
+                """),
+        })),
+    })
     @PostMapping("/api/rooms/{roomId}/apply")
     public ResponseEntity<ApplyResponse> applyForParticipate(@CurrentMember Member member,
                                                              @PathVariable String roomId) {

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/mapper/RoomWaitingMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/mapper/RoomWaitingMapper.java
@@ -15,6 +15,7 @@ public class RoomWaitingMapper {
         private Long memberId;
         private String nickname;
         private String imageUrl;
+        private boolean isCertified;
         private int matchingCount;
         private boolean thisIsMe;
 
@@ -23,6 +24,7 @@ public class RoomWaitingMapper {
             return RoomWaitingResponse.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
+                .isCertified(member.isCertified())
                 .imageUrl(member.getImageUrl())
                 .matchingCount(member.getMatchingCount())
                 .thisIsMe(thisIsMe)
@@ -44,6 +46,7 @@ public class RoomWaitingMapper {
         private Long memberId;
         private String nickname;
         private String imageUrl;
+        private boolean isCertified;
         private int matchingCount;
         private boolean thisIsMe;
 
@@ -52,6 +55,7 @@ public class RoomWaitingMapper {
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .imageUrl(member.getImageUrl())
+                .isCertified(member.isCertified())
                 .matchingCount(member.getMatchingCount())
                 .thisIsMe(thisIsMe)
                 .build();

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/mapper/RoomWaitingMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/mapper/RoomWaitingMapper.java
@@ -2,11 +2,10 @@ package com.modutaxi.api.domain.roomwaiting.mapper;
 
 import com.modutaxi.api.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.List;
 
 public class RoomWaitingMapper {
     @Getter
@@ -16,13 +15,16 @@ public class RoomWaitingMapper {
         private Long memberId;
         private String nickname;
         private String imageUrl;
+        private int matchingCount;
         private boolean thisIsMe;
 
-        public static RoomWaitingResponse toDto(Member member, boolean thisIsMe) { //TODO Mapper 로 전환 요망
+        public static RoomWaitingResponse toDto(Member member,
+            boolean thisIsMe) { //TODO Mapper 로 전환 요망
             return RoomWaitingResponse.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .imageUrl(member.getImageUrl())
+                .matchingCount(member.getMatchingCount())
                 .thisIsMe(thisIsMe)
                 .build();
         }
@@ -42,6 +44,7 @@ public class RoomWaitingMapper {
         private Long memberId;
         private String nickname;
         private String imageUrl;
+        private int matchingCount;
         private boolean thisIsMe;
 
         public static MemberRoomInResponse toDto(Member member, boolean thisIsMe) {
@@ -49,6 +52,7 @@ public class RoomWaitingMapper {
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .imageUrl(member.getImageUrl())
+                .matchingCount(member.getMatchingCount())
                 .thisIsMe(thisIsMe)
                 .build();
         }

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
@@ -42,6 +42,10 @@ public class RoomWaitingService {
      * 방 참가 신청
      */
     public ApplyResponse applyForParticipate(Member member, String roomId){
+        if (member.isBlocked()) {
+            throw new BaseException(MemberErrorCode.BLOCKED_MEMBER);
+        }
+
         Room room = roomRepository.findById(Long.valueOf(roomId)).orElseThrow(
                 () -> new BaseException(RoomErrorCode.EMPTY_ROOM));
 


### PR DESCRIPTION
## 요약 🎀

- 6월 4일(화) 진행 된 중간 회의에서 결정된, 신고하기 API 관련 수정 사항을 반영했습니다.

## 상세 내용 🌈

- `Report` 엔티티에 `roomId`를 추가했습니다.
- 로그인, 리프레쉬 API에서 임시 차단된 멤버라면 BaseException(BLOCKED_MEMBER)이 내려갔었습니다. 이 부분 삭제 했습니다. 
- 대신 로그인, 리프레쉬 성공 시 내려가는 MemberInfoResponse에 `blocked`를 추가했습니다. (프론트에서 버튼 비활성화)
- 임시 차단된 멤버가 **방 생성 API, 대기열 참여 API**를 요청 시 BaseException(BLOCKED_MEMBER)이 내려갑니다.

## 질문 및 이외 사항 🚩

- 임시 차단 멤버라면 프론트에서 버튼들을 비활성화 하겠지만, 서버에서 방어코드를 더 추가할 API가 있을까요?0?  

## 리뷰어에게 ✨

- 빠른 어프루브 부탁드립니다.....
