### PR TITLE
[MS-158] 경로 조회시 경로 최대 최소 지점 반환

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/room/dto/RoomResponseDto.java
@@ -59,6 +59,14 @@ public class RoomResponseDto {
         private int expectedChargePerPerson;
         @Schema(example = "15000", description = "예상 요금")
         private int expectedCharge;
+        @Schema(example = "125.68557", description = "최소 경도")
+        private double minLongitude;
+        @Schema(example = "36.46761", description = "최소 위도")
+        private double minLatitude;
+        @Schema(example = "126.68557", description = "최대 경도")
+        private double maxLongitude;
+        @Schema(example = "37.46761", description = "최대 위도")
+        private double maxLatitude;
         @Schema(description = "경로")
         private LineString path;
     }

--- a/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/room/mapper/RoomMapper.java
@@ -2,6 +2,8 @@ package com.modutaxi.api.domain.room.mapper;
 
 import static com.modutaxi.api.common.converter.RoomTagBitMaskConverter.convertBitMaskToRoomTagList;
 
+import com.modutaxi.api.common.exception.BaseException;
+import com.modutaxi.api.common.exception.errorcode.TaxiInfoErrorCode;
 import com.modutaxi.api.common.util.time.TimeFormatConverter;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.room.dao.RoomMysqlResponse.SearchIntegrationResponse;
@@ -74,6 +76,10 @@ public class RoomMapper {
             .expectedChargePerPerson((room.getExpectedCharge()) / (room.getWishHeadcount() + 1))
             .expectedCharge(room.getExpectedCharge())
             .path(path)
+            .minLongitude(path.getCoordinates().stream().mapToDouble(coordinate -> coordinate.getValues().get(0)).min().orElseThrow(() -> new BaseException(TaxiInfoErrorCode.EMPTY_TAXI_INFO)))
+            .minLatitude(path.getCoordinates().stream().mapToDouble(coordinate -> coordinate.getValues().get(1)).min().orElseThrow(() -> new BaseException(TaxiInfoErrorCode.EMPTY_TAXI_INFO)))
+            .maxLongitude(path.getCoordinates().stream().mapToDouble(coordinate -> coordinate.getValues().get(0)).max().orElseThrow(() -> new BaseException(TaxiInfoErrorCode.EMPTY_TAXI_INFO)))
+            .maxLatitude(path.getCoordinates().stream().mapToDouble(coordinate -> coordinate.getValues().get(1)).max().orElseThrow(() -> new BaseException(TaxiInfoErrorCode.EMPTY_TAXI_INFO)))
             .build();
     }
 


### PR DESCRIPTION
## 요약 🎀
- 경로 조회 시 경로 최대 최소 지점 반환

## 상세 내용 🌈
- 경로 조회 시 경로 최대 최소 지점 반환
  - 다음과 같은 경우에 현재의 API는 출발, 도착지점의 위경도만 반환하고 있어 경로가 보이지 않는 경우가 존재했습니다. 이를 보완하기 위해 경로상의 위도경도 최소 최댓값을 반환하도록 하여 개선하였습니다.
  <img width="277" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/ed50dae5-0616-42af-8f53-4a101a37cf1d">
