### PR TITLE
[MS-148] 객체 업로드 시 현재 프로파일 호출 방법 수정

### DIFF
--- a/src/main/java/com/modutaxi/api/common/s3/S3Service.java
+++ b/src/main/java/com/modutaxi/api/common/s3/S3Service.java
@@ -10,6 +10,7 @@ import com.modutaxi.api.common.s3.dto.S3Response.S3UploadResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +27,7 @@ import java.util.List;
 public class S3Service {
 
     private final AmazonS3Client amazonS3Client;
+    private final Environment environment;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -57,7 +59,7 @@ public class S3Service {
         }
         ObjectTagging objectTagging = new ObjectTagging(tagList);
 
-        fileName = (System.getProperty("spring.profiles.active") == null ? "local" : System.getProperty("spring.profiles.active")) + "/" + fileName;
+        fileName = (environment.getProperty("spring.profiles.active") == null ? "local" : environment.getProperty("spring.profiles.active")) + "/" + fileName;
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3Client.putObject(


### PR DESCRIPTION
## 요약 🎀
- 객체 업로드 시 현재 프로파일 호출 방법 수정

## 상세 내용 🌈
- 객체 업로드 시 현재 프로파일 호출 방법 수정
- 시스템의 환경변수로 존재하지 않는 `spring.profiles.active` 대신 스프링의 환경변수 `spring.profiles.active`를 불러오는 방식으로 수정하였습니다.