### PR TITLE
[MS-143] 알림 API

### DIFF
--- a/src/main/java/com/modutaxi/api/common/fcm/FcmService.java
+++ b/src/main/java/com/modutaxi/api/common/fcm/FcmService.java
@@ -10,9 +10,7 @@ import com.modutaxi.api.common.exception.errorcode.ChatErrorCode;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chatmessage.entity.MessageType;
 import com.modutaxi.api.domain.member.entity.Member;
-
 import java.util.Collections;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,8 +28,8 @@ public class FcmService {
         String fcmToken = validateAndGetFcmToken(memberId);
         try {
             FirebaseMessaging.getInstance()
-                    .subscribeToTopic(
-                            Collections.singletonList(fcmToken), Long.toString(roomId));
+                .subscribeToTopic(
+                    Collections.singletonList(fcmToken), Long.toString(roomId));
             log.info("FCM SUBSCRIBE");
         } catch (FirebaseMessagingException e) {
             log.error("FAIL FCM SUBSCRIBE");
@@ -43,8 +41,8 @@ public class FcmService {
         String fcmToken = validateAndGetFcmToken(memberId);
         try {
             FirebaseMessaging.getInstance()
-                    .unsubscribeFromTopic(
-                            Collections.singletonList(fcmToken), Long.toString(roomId));
+                .unsubscribeFromTopic(
+                    Collections.singletonList(fcmToken), Long.toString(roomId));
         } catch (FirebaseMessagingException e) {
             throw new BaseException(ChatErrorCode.FAIL_FCM_UNSUBSCRIBE);
         }
@@ -62,17 +60,17 @@ public class FcmService {
     }
 
     // TODO: 5/14/24 프론트 측 테스트를 위한 메서드입니다.
-    public void testSend(Member member){
+    public void testSend(Member member) {
         String fcmToken = validateAndGetFcmToken(member.getId());
         Message message = Message.builder()
-                .putData("messageType", "TEST")
-                .putData("message", "테스트메세지")
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("테스트메세지")
-                        .build())
-                .build();
+            .putData("messageType", "TEST")
+            .putData("message", "테스트메세지")
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("테스트메세지")
+                .build())
+            .build();
         send(message);
     }
 
@@ -81,19 +79,19 @@ public class FcmService {
      */
     public void sendChatMessage(ChatMessageRequestDto chatMessageRequestDto) {
         Message message = Message.builder()
-                .putData("roomId", Long.toString(chatMessageRequestDto.getRoomId()))
-                .putData("messageType", chatMessageRequestDto.getType().toString())
-                .putData("message", chatMessageRequestDto.getContent())
-                .putData("sender", chatMessageRequestDto.getSender())
-                .putData("memberId", chatMessageRequestDto.getMemberId())
-                .putData("dateTime", chatMessageRequestDto.getDateTime().toString())
-                .setTopic(chatMessageRequestDto.getRoomId().toString())
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody(chatMessageRequestDto.getType().equals(MessageType.IMAGE)
-                                ? "사진" : chatMessageRequestDto.getContent())
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(chatMessageRequestDto.getRoomId()))
+            .putData("messageType", chatMessageRequestDto.getType().toString())
+            .putData("message", chatMessageRequestDto.getContent())
+            .putData("sender", chatMessageRequestDto.getSender())
+            .putData("memberId", chatMessageRequestDto.getMemberId())
+            .putData("dateTime", chatMessageRequestDto.getDateTime().toString())
+            .setTopic(chatMessageRequestDto.getRoomId().toString())
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody(chatMessageRequestDto.getType().equals(MessageType.IMAGE)
+                    ? "사진" : chatMessageRequestDto.getContent())
+                .build())
+            .build();
         send(message);
     }
 
@@ -102,16 +100,16 @@ public class FcmService {
      */
     public void sendUpdateRoomInfo(Long managerId, Long roomId) {
         Message message = Message.builder()
-                .putData("messageType", "ROOM_UPDATE")
-                .putData("roomId", Long.toString(roomId))
-                .putData("message", "참여해 있는 방 정보가 업데이트 되었습니다.")
-                .putData("managerId", managerId.toString())
-                .setTopic(roomId.toString())
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("참여해 있는 방 정보가 업데이트 되었습니다.")
-                        .build())
-                .build();
+            .putData("messageType", "ROOM_UPDATE")
+            .putData("roomId", Long.toString(roomId))
+            .putData("message", "참여해 있는 방 정보가 업데이트 되었습니다.")
+            .putData("managerId", managerId.toString())
+            .setTopic(roomId.toString())
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("참여해 있는 방 정보가 업데이트 되었습니다.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -119,18 +117,18 @@ public class FcmService {
     /**
      * 새로운 참여자의 참요 요청 알림, 방장에게
      */
-    public void sendNewParticipant(Member roomManager, String roomId) {
+    public void sendNewParticipant(Member roomManager, String roomId, String nickName) {
         String fcmToken = validateAndGetFcmToken(roomManager.getId());
         Message message = Message.builder()
-                .putData("messageType", "PARTICIPATE_REQUEST")
-                .putData("message", "새로운 참가자의 참가 요청이 들어왔습니다.")
-                .putData("roomId", roomId)
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("새로운 참가자의 참가 요청이 들어왔습니다.")
-                        .build())
-                .build();
+            .putData("messageType", "PARTICIPATE_REQUEST")
+            .putData("message", nickName + "님이 매칭 대기중이에요!")
+            .putData("roomId", roomId)
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody(nickName + "님이 매칭 대기중이에요!")
+                .build())
+            .build();
         send(message);
     }
 
@@ -140,16 +138,16 @@ public class FcmService {
     // TODO: 5/12/24 아직 쓰는 곳 없음. API 만들어야 함.
     public void sendSuccessMatching(Long managerId, Long roomId) {
         Message message = Message.builder()
-                .putData("roomId", Long.toString(roomId))
-                .putData("messageType", "MATCHING_COMPLETE")
-                .putData("message", "방 매칭이 완료되었습니다.")
-                .putData("managerId", managerId.toString())
-                .setTopic(roomId.toString())
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("방 매칭이 완료되었습니다.")
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(roomId))
+            .putData("messageType", "MATCHING_COMPLETE")
+            .putData("message", "방 매칭이 완료되었습니다.")
+            .putData("managerId", managerId.toString())
+            .setTopic(roomId.toString())
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("방 매칭이 완료되었습니다.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -160,16 +158,16 @@ public class FcmService {
     public void sendRequestPayment(Member member, Long roomId, int bill) {
         String fcmToken = validateAndGetFcmToken(member.getId());
         Message message = Message.builder()
-                .putData("roomId", Long.toString(roomId))
-                .putData("messageType", "REMIT_REQUEST")
-                .putData("message", "정산해주세요.")
-                .putData("bill", String.valueOf(bill))
-                .setTopic(roomId.toString())
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("정산해주세요.")
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(roomId))
+            .putData("messageType", "REMIT_REQUEST")
+            .putData("message", "정산해주세요.")
+            .putData("bill", String.valueOf(bill))
+            .setTopic(roomId.toString())
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("정산해주세요.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -178,16 +176,16 @@ public class FcmService {
      */
     public void sendDeleteRoom(Long managerId, Long roomId) {
         Message message = Message.builder()
-                .putData("roomId", Long.toString(roomId))
-                .putData("messageType", "ROOM_DELETE")
-                .putData("message", "방이 삭제 되었습니다.")
-                .putData("managerId", managerId.toString())
-                .setTopic(roomId.toString())
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("방이 삭제 되었습니다.")
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(roomId))
+            .putData("messageType", "ROOM_DELETE")
+            .putData("message", "방이 삭제 되었습니다.")
+            .putData("managerId", managerId.toString())
+            .setTopic(roomId.toString())
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("방이 삭제 되었습니다.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -197,15 +195,15 @@ public class FcmService {
     public void sendPermitParticipate(Member participant, String roomId) {
         String fcmToken = validateAndGetFcmToken(participant.getId());
         Message message = Message.builder()
-                .putData("messageType", "MATCHING_SUCCESS")
-                .putData("message", "방 매칭에 성공했습니다.")
-                .putData("roomId", roomId)
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("방 매칭에 성공했습니다.")
-                        .build())
-                .build();
+            .putData("messageType", "MATCHING_SUCCESS")
+            .putData("message", "매칭이 수락되었어요! 지금 바로 채팅을 시작하세요.")
+            .putData("roomId", roomId)
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("매칭이 수락되었어요! 지금 바로 채팅을 시작하세요.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -215,15 +213,15 @@ public class FcmService {
     public void sendDepartureTime(Member member, Long roomId) {
         String fcmToken = validateAndGetFcmToken(member.getId());
         Message message = Message.builder()
-                .putData("roomId", Long.toString(roomId))
-                .putData("messageType", "TIME_TO_DEPART")
-                .putData("message", "예정되어 있던 출발 시간이 되었습니다.")
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("예정되어 있던 출발 시간이 되었습니다.")
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(roomId))
+            .putData("messageType", "TIME_TO_DEPART")
+            .putData("message", "예정되어 있던 출발 시간이 되었습니다.")
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("예정되어 있던 출발 시간이 되었습니다.")
+                .build())
+            .build();
         send(message);
     }
 
@@ -233,18 +231,17 @@ public class FcmService {
     public void send10MinutesBeforeDepartureTime(Member member, Long roomId) {
         String fcmToken = validateAndGetFcmToken(member.getId());
         Message message = Message.builder()
-                .putData("roomId", Long.toString(roomId))
-                .putData("messageType", "DEPART_10_MINUTES_AGO")
-                .putData("message", "출발 10분 전입니다.")
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle("모두의택시")
-                        .setBody("출발 10분 전입니다.")
-                        .build())
-                .build();
+            .putData("roomId", Long.toString(roomId))
+            .putData("messageType", "DEPART_10_MINUTES_AGO")
+            .putData("message", "출발 10분 전입니다.")
+            .setToken(fcmToken)
+            .setNotification(Notification.builder()
+                .setTitle("모두의택시")
+                .setBody("출발 10분 전입니다.")
+                .build())
+            .build();
         send(message);
     }
-
 
     public String validateAndGetFcmToken(Long memberId) {
         String fcmToken = redisFcmRepository.findById(memberId);

--- a/src/main/java/com/modutaxi/api/domain/alarm/controller/GetAlarmController.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/controller/GetAlarmController.java
@@ -1,0 +1,42 @@
+package com.modutaxi.api.domain.alarm.controller;
+
+import com.modutaxi.api.common.auth.CurrentMember;
+import com.modutaxi.api.common.pagination.PageResponseDto;
+import com.modutaxi.api.domain.alarm.dto.AlarmResponseDto.AlarmInfo;
+import com.modutaxi.api.domain.alarm.service.GetAlarmService;
+import com.modutaxi.api.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/alarms")
+@Tag(name = "알림")
+public class GetAlarmController {
+
+    private final GetAlarmService getAlarmService;
+
+    @Operation(summary = "알림 목록 조회", description = "내 알림 목록을 조회합니다.<br>page와 size를 입력해주세요!")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = AlarmInfo.class))),
+    })
+    @GetMapping("")
+    public ResponseEntity<PageResponseDto<List<AlarmInfo>>> getAlarmList(
+        @CurrentMember Member member,
+        @Parameter(description = "조회할 page") @RequestParam int page,
+        @Parameter(description = "조회할 page 단위") @RequestParam int size) {
+        return ResponseEntity.ok(getAlarmService.getAlarmList(member, page, size));
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/dto/AlarmResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/dto/AlarmResponseDto.java
@@ -1,0 +1,20 @@
+package com.modutaxi.api.domain.alarm.dto;
+
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AlarmResponseDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class AlarmInfo {
+        private AlarmType type;
+        private String message;
+        private Long resourceId;
+        private LocalDateTime dateTime;
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/entity/Alarm.java
@@ -1,0 +1,32 @@
+package com.modutaxi.api.domain.alarm.entity;
+
+import com.modutaxi.api.common.entity.BaseTime;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private AlarmType type;
+
+    private Long resourceId;    // 이동 대상의 id (ex. roomId)
+
+    private Long memberId;      // 알림 주인 id
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,25 @@
+package com.modutaxi.api.domain.alarm.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AlarmType {
+
+    // 매칭
+    PARTICIPATE_REQUEST("새로운 멤버가 매칭 대기중이에요!"),
+    MATCHING_SUCCESS("매칭이 수락되었어요! 지금 바로 채팅을 시작하세요."),
+    MATCHING_COMPLETE("모든 인원이 모였어요. 매칭 완료를 눌러주세요."),
+
+    // 신고
+    REPORT_SUCCESS("신고가 접수되었어요, 빨리 해결해드릴게요!"),
+
+    // 정산
+    PAYMENT_REQUEST("정산 금액을 입력해주세요."),
+    PAYMENT_REQUEST_COMPLETE("정산 요청이 들어왔어요. 금액을 확인해주세요."),
+    PAYMENT_ALL_COMPLETE("정산이 완료되었어요!");
+
+    private final String message;
+
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
@@ -1,0 +1,17 @@
+package com.modutaxi.api.domain.alarm.mapper;
+
+import com.modutaxi.api.domain.alarm.entity.Alarm;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AlarmMapper {
+
+    public static Alarm toEntity(AlarmType type, Long resourceId, Long memberId) {
+        return Alarm.builder()
+            .type(type)
+            .resourceId(resourceId)
+            .memberId(memberId)
+            .build();
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
@@ -1,5 +1,6 @@
 package com.modutaxi.api.domain.alarm.mapper;
 
+import com.modutaxi.api.domain.alarm.dto.AlarmResponseDto.AlarmInfo;
 import com.modutaxi.api.domain.alarm.entity.Alarm;
 import com.modutaxi.api.domain.alarm.entity.AlarmType;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,15 @@ public class AlarmMapper {
             .type(type)
             .resourceId(resourceId)
             .memberId(memberId)
+            .build();
+    }
+
+    public static AlarmInfo toDto(Alarm alarm) {
+        return AlarmInfo.builder()
+            .type(alarm.getType())
+            .message(alarm.getType().getMessage())
+            .resourceId(alarm.getResourceId())
+            .dateTime(alarm.getCreatedAt())
             .build();
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,7 @@
+package com.modutaxi.api.domain.alarm.repository;
+
+import com.modutaxi.api.domain.alarm.entity.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
@@ -1,7 +1,11 @@
 package com.modutaxi.api.domain.alarm.repository;
 
 import com.modutaxi.api.domain.alarm.entity.Alarm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+    Page<Alarm> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/modutaxi/api/domain/alarm/service/GetAlarmService.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/service/GetAlarmService.java
@@ -1,0 +1,29 @@
+package com.modutaxi.api.domain.alarm.service;
+
+import com.modutaxi.api.common.pagination.PageResponseDto;
+import com.modutaxi.api.domain.alarm.dto.AlarmResponseDto.AlarmInfo;
+import com.modutaxi.api.domain.alarm.entity.Alarm;
+import com.modutaxi.api.domain.alarm.mapper.AlarmMapper;
+import com.modutaxi.api.domain.alarm.repository.AlarmRepository;
+import com.modutaxi.api.domain.member.entity.Member;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetAlarmService {
+
+    private final AlarmRepository alarmRepository;
+
+    public PageResponseDto<List<AlarmInfo>> getAlarmList(Member member, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Alarm> alarms = alarmRepository.findByMemberIdOrderByCreatedAtDesc(member.getId(),
+            pageable);
+        List<AlarmInfo> alarmInfos = alarms.stream().map(AlarmMapper::toDto).toList();
+        return new PageResponseDto<>(page, alarms.hasNext(), alarmInfos);
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/alarm/service/RegisterAlarmService.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/service/RegisterAlarmService.java
@@ -1,0 +1,23 @@
+package com.modutaxi.api.domain.alarm.service;
+
+import static com.modutaxi.api.domain.alarm.mapper.AlarmMapper.toEntity;
+
+import com.modutaxi.api.domain.alarm.entity.Alarm;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import com.modutaxi.api.domain.alarm.repository.AlarmRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterAlarmService {
+
+    private final AlarmRepository alarmRepository;
+
+    @Transactional
+    public void registerAlarm(AlarmType type, Long resourceId, Long memberId) {
+        Alarm alarm =  toEntity(type, resourceId, memberId);
+        alarmRepository.save(alarm);
+    }
+}

--- a/src/main/java/com/modutaxi/api/domain/paymentmember/service/UpdatePaymentMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/paymentmember/service/UpdatePaymentMemberService.java
@@ -3,6 +3,8 @@ package com.modutaxi.api.domain.paymentmember.service;
 import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.PaymentErrorCode;
 import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import com.modutaxi.api.domain.alarm.service.RegisterAlarmService;
 import com.modutaxi.api.domain.chat.service.ChatService;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
 import com.modutaxi.api.domain.chatmessage.entity.MessageType;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 public class UpdatePaymentMemberService {
 
     private final GetPaymentRoomService getPaymentRoomService;
+    private final RegisterAlarmService registerAlarmService;
     private final ChatService chatService;
 
     private final PaymentMemberRepository paymentMemberRepository;
@@ -91,6 +94,10 @@ public class UpdatePaymentMemberService {
                     room.getRoomManager().getId().toString(),
                     LocalDateTime.now(), "");
             chatService.sendChatMessage(paymentCompleteMessageRequestDto);
+
+            // 알림 저장
+            registerAlarmService.registerAlarm(AlarmType.PAYMENT_ALL_COMPLETE, roomId,
+                room.getRoomManager().getId());
         }
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
+++ b/src/main/java/com/modutaxi/api/domain/report/service/RegisterReportService.java
@@ -7,6 +7,8 @@ import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.common.exception.errorcode.ReportErrorCode;
 import com.modutaxi.api.common.slack.SlackService;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import com.modutaxi.api.domain.alarm.service.RegisterAlarmService;
 import com.modutaxi.api.domain.mail.service.MailServiceImpl;
 import com.modutaxi.api.domain.member.entity.Member;
 import com.modutaxi.api.domain.member.repository.MemberRepository;
@@ -15,7 +17,6 @@ import com.modutaxi.api.domain.report.entity.Report;
 import com.modutaxi.api.domain.report.entity.ReportType;
 import com.modutaxi.api.domain.report.repository.ReportRepository;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public class RegisterReportService {
     private final ReportRepository reportRepository;
     private final SlackService slackService;
     private final MailServiceImpl mailService;
+    private final RegisterAlarmService registerAlarmService;
 
     public ReportResponse register(
         Long reporterId, Long targetId, Long roomId, ReportType type, String content) {
@@ -45,6 +47,9 @@ public class RegisterReportService {
         // 저장
         Report report = toEntity(reporterId, targetId, roomId, type, content);
         reportRepository.save(report);
+
+        // 알림 저장
+        registerAlarmService.registerAlarm(AlarmType.REPORT_SUCCESS, 0L, reporterId);
 
         // 관리자 슬랙에 메시지 전송
         slackService.sendReportMessage(report);

--- a/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
+++ b/src/main/java/com/modutaxi/api/domain/room/service/UpdateRoomService.java
@@ -12,6 +12,8 @@ import com.modutaxi.api.common.exception.errorcode.SpotError;
 import com.modutaxi.api.common.exception.errorcode.TaxiInfoErrorCode;
 import com.modutaxi.api.common.fcm.FcmService;
 import com.modutaxi.api.common.util.time.TimeFormatConverter;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import com.modutaxi.api.domain.alarm.service.RegisterAlarmService;
 import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
 import com.modutaxi.api.domain.chat.service.ChatService;
 import com.modutaxi.api.domain.chatmessage.dto.ChatMessageRequestDto;
@@ -64,6 +66,7 @@ public class UpdateRoomService {
     private final ChatService chatService;
     private final GetParticipantService getParticipantService;
     private final ParticipantRepository participantRepository;
+    private final RegisterAlarmService registerAlarmService;
 
     @Transactional
     public RoomDetailResponse updateRoom(Member member, Long roomId,
@@ -124,7 +127,7 @@ public class UpdateRoomService {
 
         //참가자들의 매핑된 방 정보 삭제
         participantRepository.deleteAllByRoom(room);
-        
+
         memberRoomInResponseList.getInList().forEach(item -> {
                 try {
                     log.info("{}번 유저 삭제하겠습니다.", item.getMemberId());
@@ -295,6 +298,8 @@ public class UpdateRoomService {
                 LocalDateTime.now(), "");
 
         chatService.sendChatMessage(matchingCompleteMessageRequestDto);
+        registerAlarmService.registerAlarm(AlarmType.PAYMENT_REQUEST, roomId,
+            room.getRoomManager().getId());
         chatService.sendChatMessage(taxiInfoMessageRequestDto);
 
         return new UpdateRoomResponse(true);

--- a/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
+++ b/src/main/java/com/modutaxi/api/domain/roomwaiting/service/RoomWaitingService.java
@@ -6,6 +6,8 @@ import com.modutaxi.api.common.exception.errorcode.MemberErrorCode;
 import com.modutaxi.api.common.exception.errorcode.ParticipateErrorCode;
 import com.modutaxi.api.common.exception.errorcode.RoomErrorCode;
 import com.modutaxi.api.common.fcm.FcmService;
+import com.modutaxi.api.domain.alarm.entity.AlarmType;
+import com.modutaxi.api.domain.alarm.service.RegisterAlarmService;
 import com.modutaxi.api.domain.chat.ChatRoomMappingInfo;
 import com.modutaxi.api.domain.chat.dto.ChatResponseDto.DeleteResponse;
 import com.modutaxi.api.domain.chat.repository.RedisChatRoomRepositoryImpl;
@@ -17,8 +19,8 @@ import com.modutaxi.api.domain.room.repository.RoomRepository;
 import com.modutaxi.api.domain.roomwaiting.dto.RoomWaitingResponseDto.ApplyResponse;
 import com.modutaxi.api.domain.roomwaiting.dto.RoomWaitingResponseDto.RoomWaitingResponseList;
 import com.modutaxi.api.domain.roomwaiting.entity.RoomWaiting;
-import com.modutaxi.api.domain.roomwaiting.repository.RoomWaitingRepository;
 import com.modutaxi.api.domain.roomwaiting.mapper.RoomWaitingMapper;
+import com.modutaxi.api.domain.roomwaiting.repository.RoomWaitingRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,6 +37,7 @@ public class RoomWaitingService {
     private final FcmService fcmService;
     private final MemberRepository memberRepository;
     private final RoomWaitingRepository roomWaitingRepository;
+    private final RegisterAlarmService registerAlarmService;
 
     /**
      * 방 참가 신청 - 대기열 등
@@ -77,7 +80,9 @@ public class RoomWaitingService {
         }
 
         roomWaitingRepository.save(RoomWaitingMapper.toEntity(member, room));
-        fcmService.sendNewParticipant(room.getRoomManager(), roomId);
+        fcmService.sendNewParticipant(room.getRoomManager(), roomId, member.getNickname());
+        registerAlarmService.registerAlarm(
+            AlarmType.PARTICIPATE_REQUEST, Long.valueOf(roomId), room.getRoomManager().getId());
         return new ApplyResponse(true);
     }
 


### PR DESCRIPTION
## 요약 🎀

- 알림 생성
- 알림 목록 조회 API 

## 상세 내용 🌈
- 아래 화면에 해당되는 API 작업을 진행했습니다. 문구는 헷갈리지 않게 바꿨습니다!
   
   ![image](https://github.com/MODU-TAXI/server-api/assets/71329329/6627e5b1-bd99-4558-a59a-46bbc016722b)

- Alarm Entity
  - 알림 엔티티는 아래와 같습니다. 현재로써는 `roomId`만을 이용하여 알림에 알맞는 화면으로 바로 이동하지만, 확장성을 고려하여 `resourcId`라고 포괄적으로 네이밍했습니다!
  
  ```java
   public class Alarm extends BaseTime {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
    
    @NotNull
    private AlarmType type;
    private Long resourceId;      // 이동 대상의 id (ex. roomId)
    private Long memberId;      // 알림 주인 id
    }
  ```
- Alarm Type
  - 알림 타입은 현재 총 7가지입니다. 신고하기 말고는 테스트를 못 해봐서, 연동 후에 같이 테스트 해보면 좋을 것 같습니다!
  ```java
   @Getter
   @AllArgsConstructor
   public enum AlarmType {

    // 매칭
    PARTICIPATE_REQUEST("새로운 멤버가 매칭 대기중이에요!"),
    MATCHING_SUCCESS("매칭이 수락되었어요! 지금 바로 채팅을 시작하세요."),
    MATCHING_COMPLETE("모든 인원이 모였어요. 매칭 완료를 눌러주세요."),

    // 신고
    REPORT_SUCCESS("신고가 접수되었어요, 빨리 해결해드릴게요!"),

    // 정산
    PAYMENT_REQUEST("정산 금액을 입력해주세요."),
    PAYMENT_REQUEST_COMPLETE("정산 요청이 들어왔어요. 금액을 확인해주세요."),
    PAYMENT_ALL_COMPLETE("정산이 완료되었어요!");

    private final String message;

   }
  ```
- Response Dto
  - 알림 목록 조회시 아래와 같은 응답이 내려갑니다.
  ```java
    public static class AlarmInfo {
        private AlarmType type;
        private String message;
        private Long resourceId;
        private LocalDateTime dateTime;
    }
  ```

## 질문 및 이외 사항 🚩

- 이미 존재하는 FCM 타입의 경우, 동일하게 네이밍 했습니다. 뭔가 알림 타입과 메시지 타입을 한번에 관리하고 싶은데... 당장은 어떻게 해야할지 잘 모르겠네요!..

## 리뷰어에게 ✨

- 궁금한 점 있으시다면 댓글 달아주세요!
