### PR TITLE
[MS-45] 로그인 로직 변경

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/RegisterMemberController.java
@@ -56,20 +56,14 @@ public class RegisterMemberController {
      */
     @Operation(
         summary = "소셜 로그인",
-        description = "type: KAKAO, APPLE<br>"
+        description = "type: KAKAO, APPLE<br>로그인에 성공한 경우와 회원가입이 필요한 경우 둘 다 실제로는 200으로 내려가지만, 스웨거에서 응답을 구분하기 위해 201로 해두었습니다. 착오 없으시길 바랍니다!"
     )
     @ApiResponses({
-        @ApiResponse(responseCode = "409", description = "로그인 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberErrorCode.class), examples = {
-            @ExampleObject(name = "MEMBER_001", description = "존재하지 않는 사용자", value = """
-                {
-                    "errorCode": "MEMBER_001",
-                    "message": "존재하지 않는 사용자입니다."
-                }
-                """),
-        })),
+        @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenAndMemberResponse.class))),
+        @ApiResponse(responseCode = "201", description = "로그인 실패 회원가입 필요", content = @Content(mediaType = "application/json", schema = @Schema(implementation = MembershipResponse.class))),
     })
     @PostMapping("/{type}/login")
-    public ResponseEntity<TokenAndMemberResponse> login(
+    public ResponseEntity<?> login(
         @PathVariable(name = "type") SocialLoginType type,
         @Valid @RequestBody LoginRequest loginRequest) throws IOException {
         return ResponseEntity.ok(registerMemberService.login(
@@ -78,17 +72,6 @@ public class RegisterMemberController {
             loginRequest.getFcmToken()));
     }
 
-    /**
-     * [POST] 가입 여부 확인 /{type}/membership
-     */
-    @Operation(summary = "가입 여부 확인")
-    @PostMapping("/{type}/membership")
-    public ResponseEntity<MembershipResponse> checkMembership(
-        @PathVariable(name = "type") SocialLoginType type,
-        @Valid @RequestBody LoginRequest loginRequest) throws IOException {
-        return ResponseEntity.ok(registerMemberService.checkMembership(
-            type, loginRequest.getAccessToken()));
-    }
 
     /**
      * [POST] 로그아웃 /logout

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberResponseDto.java
@@ -33,7 +33,6 @@ public class MemberResponseDto {
     @Getter
     @AllArgsConstructor
     public static class MembershipResponse {
-        private boolean existent;
         private String key;
     }
 


### PR DESCRIPTION
## 요약 🎀

- 프론트 요청 사항에 따라 로그인 로직을 변경했습니다.

## 상세 내용 🌈

- 기존 방식
  - 먼저 **가입 여부 확인 API**를 통해 snsId를 가진 계정이 존재하는지 체크합니다. 
  - 이때 계정이 존재하지 않는다면 false를 반환하고, 레디스에 해당 snsId를 저장한 key를 함께 내려줍니다. → 프론트의 **회원가입** API 호출
  - 만약 계정이 존재한다면 true를 반환하고, key는 빈값으로 내려줍니다. → 프론트의 **로그인 API** 호출
- 변경한 방식
  - 기존의 가입 여부 확인 API와 로그인 API를 **로그인 API 하나로** 합쳤습니다! Response 값을 와일드 카드로 선언하여 해결했습니다.
  - 가입된 멤버라면 아래와 같이 TokenAndMemberResponse가 내려갑니다.
    ```json
    {
      "tokenResponse": {
        "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6MSwiaWF0IjoxNzE4OTA2Mjk0LCJleHAiOjE3MTg5MDk4OTR9.MxnraY8YpcnzeW7_cmmEtOI2RZoVR4pqlmEEGoaOzb8",
        "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJtZW1iZXJJZCI6MSwiaWF0IjoxNzE4OTA2Mjk0LCJleHAiOjE3MTk1MTEwOTR9.1pJl39XIUB2_or-JhAQ8JqzuU_95dxQxjCPn4FNLXm0"
      },
      "memberInfoResponse": {
        "id": 1,
        "name": "유지수",
        "nickname": "1지수",
        "gender": "FEMALE",
        "phoneNumber": "010-5678-1234",
        "email": null,
        "imageUrl": "https://cdn.modutaxi.shop/common/default-profile.png",
        "matchingCount": 0,
        "blocked": false
      }
    }
    ```

  - 가입되지 않은 멤버라면 MembershipResponse가 내려갑니다.
    ```json
    {
      "key": "d53d5e67-3e34-4ea8-a6ce-2c37e1c1e9bc"
    }
    ```
## 질문 및 이외 사항 🚩

- 참고한 포스팅: https://stir.tistory.com/343

## 리뷰어에게 ✨

- 궁금한 점 있으시면 댓글 달아주세요!
