### PR TITLE
[MS-170] 회원탈퇴 API

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/account/repository/AccountRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/account/repository/AccountRepository.java
@@ -20,4 +20,8 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findById(@NotNull @Param("id") Long id);
 
     List<Account> findAllByMemberAndStatusTrue(@Param("member") Member member);
+
+    void deleteByMember(@Param("member") Member member);
+
+    void deleteById(@NotNull @Param("id") Long id);
 }

--- a/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     Page<Alarm> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/modutaxi/api/domain/likedSpot/repository/LikedSpotRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/likedSpot/repository/LikedSpotRepository.java
@@ -13,6 +13,9 @@ public interface LikedSpotRepository extends JpaRepository<LikedSpot, Long> {
 
     void deleteByMemberAndSpotId(Member memberId, Long spotId);
 
+    void deleteByMember(Member member);
+
     @Query("SELECT l.spot.id as spotId, l.spot.name as spotName, l.spot.spotPoint as spotpoint FROM LikedSpot l WHERE l.member = :member ORDER BY l.createdAt DESC")
-    Slice<LikedSpotResponseInterface> findAllByOrderByCreatedAtDesc(Pageable pageable, Member member);
+    Slice<LikedSpotResponseInterface> findAllByOrderByCreatedAtDesc(Pageable pageable,
+        Member member);
 }

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -268,5 +269,21 @@ public class UpdateMemberController {
         return ResponseEntity.ok(updateMemberService.updateProfile(
             member, request.getName(), request.getGender(), request.getPhoneNumber(),
             request.getImageUrl()));
+    }
+
+    /**
+     * [DELETE] 회원 탈퇴
+     */
+    @Operation(summary = "회원 탈퇴",
+        description = "회원 탈퇴입니다.<br>헤더에 반드시 Authorization 으로 accessToken 값을 넣어주세요!<br>"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공", content = @Content(mediaType = "application/json")),
+    })
+    @DeleteMapping("")
+    public ResponseEntity<Integer> deleteMember(
+        @CurrentMember Member member) {
+        updateMemberService.deleteMember(member);
+        return ResponseEntity.ok(200);
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
+++ b/src/main/java/com/modutaxi/api/domain/member/entity/Member.java
@@ -125,4 +125,9 @@ public class Member extends BaseTime {
         this.blocked = true;
     }
 
+    public void delete() {
+        this.status = false;
+        this.nickname = "(알 수 없음)";
+    }
+
 }


### PR DESCRIPTION
## 요약 🎀

- 회원탈퇴 API를 구현했습니다.

## 상세 내용 🌈

- 회원탈퇴에서 가장 컸던 문제가 어디까지 삭제하고 어디까지 남겨둬야 하는가? 였습니다. 근데 프론트 측에서, 내가 참여 중인 방이 있다면 회원탈퇴 버튼을 비활성화해주신다고 해서, 참여 중인 방의 정보를 지우는 작업은 하지 않았습니다. 
- 택시팟, 정산, 이용 내역은 그대로 냅뒀고, 그 멤버로 인해 생겨난 리소스만 삭제했습니다.
  - account, alarm, liked_spot

## 질문 및 이외 사항 🚩

- 질문있으시면 남겨주세요

## 리뷰어에게 ✨

-
