### PR TITLE
[MS-145] Fix: Alarm 엔티티 필드 네이밍 변경

### DIFF
--- a/src/main/java/com/modutaxi/api/domain/alarm/dto/AlarmResponseDto.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/dto/AlarmResponseDto.java
@@ -16,7 +16,7 @@ public class AlarmResponseDto {
         private String message;
         private Long resourceId;
         private LocalDateTime dateTime;
-        private boolean isChecked;
+        private boolean checked;
     }
 
     @Getter

--- a/src/main/java/com/modutaxi/api/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/entity/Alarm.java
@@ -31,10 +31,10 @@ public class Alarm extends BaseTime {
     private Long memberId;      // 알림 주인 id
 
     @Builder.Default
-    private boolean isChecked = false;
+    private boolean checked = false;
 
 
     public void setCheckedTrue() {
-        this.isChecked = true;
+        this.checked = true;
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/mapper/AlarmMapper.java
@@ -22,7 +22,7 @@ public class AlarmMapper {
             .message(alarm.getType().getMessage())
             .resourceId(alarm.getResourceId())
             .dateTime(alarm.getCreatedAt())
-            .isChecked(alarm.isChecked())
+            .checked(alarm.isChecked())
             .build();
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/alarm/repository/AlarmRepository.java
@@ -1,7 +1,6 @@
 package com.modutaxi.api.domain.alarm.repository;
 
 import com.modutaxi.api.domain.alarm.entity.Alarm;
-import com.modutaxi.api.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;


### PR DESCRIPTION
## 요약 🎀

- Alarm 엔티티 필드 네이밍 변경 `isChecked -> checked`

## 상세 내용 🌈

- `isChecked` 라는 네이밍으로 인해 JPA가 기본 Method 네이밍 인식 못하는 상황 발생

## 질문 및 이외 사항 🚩

-

## 리뷰어에게 ✨

-
