### PR TITLE
[MS-174] Jwt용 sms 인증 엔드포인트 생성 및 휴대폰 번호 중복사용 방지 로직 추가

### DIFF
--- a/src/main/java/com/modutaxi/api/common/config/SecurityConfig.java
+++ b/src/main/java/com/modutaxi/api/common/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         "api/members/APPLE/login",
                         "/api/members/sign-up",
                         "/api/apple/sts",
+                        "/api/members/sms/certificate",
                         "/swagger-ui/**").permitAll() // 허용된 주소
                     .anyRequest().permitAll() // Authentication 필요한 주소
             )

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/SmsErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/SmsErrorCode.java
@@ -16,6 +16,7 @@ public enum SmsErrorCode implements ErrorCode {
     INVALID_PHONE_NUMBER_PATTERN("SMS_006", "유효하지 않은 전화번호 형식입니다.", HttpStatus.BAD_REQUEST),
     INVALID_CERTIFICATION_CODE_PATTERN("SMS_007", "유효하지 않은 인증코드 형식입니다.", HttpStatus.BAD_REQUEST),
     SMS_AGENCY_ERROR("SMS_008", "SMS 발송에 실패했습니다. 잠시후 재시도 해주세요.", HttpStatus.BAD_REQUEST),
+    ALREADY_USED_PHONE_NUMBER("SMS_009", "이미 이용중인 전화번호입니다.", HttpStatus.BAD_REQUEST),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/modutaxi/api/domain/member/dto/MemberRequestDto.java
@@ -46,7 +46,7 @@ public class MemberRequestDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class SendSmsCertificationRequest {
+    public static class SendSmsCertificationRequestWithSignupKey {
         @Schema(description = "회원가입 시 발급받은 키")
         private String key;
         @Schema(description = "인증번호를 받을 전화번호")
@@ -56,9 +56,27 @@ public class MemberRequestDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class ConfirmSmsCertificationReqeust {
+    public static class SendSmsCertificationRequestWithJwt {
+        @Schema(description = "인증번호를 받을 전화번호")
+        private String phoneNumber;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ConfirmSmsCertificationReqeustWithSignupKey {
         @Schema(description = "회원가입 시 발급받은 키")
         private String key;
+        @Schema(description = "인증번호를 받은 전화번호")
+        private String phoneNumber;
+        @Schema(description = "인증번호")
+        private String certificationCode;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ConfirmSmsCertificationReqeustWithJwt {
         @Schema(description = "인증번호를 받은 전화번호")
         private String phoneNumber;
         @Schema(description = "인증번호")

--- a/src/main/java/com/modutaxi/api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/modutaxi/api/domain/member/repository/MemberRepository.java
@@ -42,4 +42,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         "WHERE m.snsId = :snsId " +
         "AND m.status = true")
     Optional<Member> findByAppleSnsIdAndStatusTrue(@Param("snsId") String snsId);
+
+    Optional<Member> findByPhoneNumber(String phoneNumber);
 }


### PR DESCRIPTION
## 요약 🎀
- Jwt용 sms 인증 엔드포인트 생성 및 휴대폰 번호 중복사용 방지 로직 추가

## 상세 내용 🌈
- Jwt용 sms 인증 엔드포인트 생성
  - 기존의 signup key를 대신하여 jwt토큰을 이용하는 sms 인증 엔드포인트를 구현했습니다.
- 휴대폰 번호 중복사용 방지 로직 추가
  - 같은 휴대전화를 이용하여 두개의 계정을 사용할 수 없도록 검증로직을 추가하였습니다.