### PR TITLE
[MS-178] 애플 리프레시 토큰 저장 로직 추가

### DIFF
--- a/src/main/java/com/modutaxi/api/common/auth/oauth/apple/client/AppleOauthClient.java
+++ b/src/main/java/com/modutaxi/api/common/auth/oauth/apple/client/AppleOauthClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.modutaxi.api.common.auth.oauth.apple.dto.AppleAuthServerRequest.IdTokenRequest;
+import com.modutaxi.api.common.auth.oauth.apple.dto.AppleAuthServerRequest.RevokeTokenRequest;
 import com.modutaxi.api.common.auth.oauth.apple.dto.AppleAuthServerResponse.AppleSocialTokenResponse;
 import com.modutaxi.api.common.exception.BaseException;
 import com.modutaxi.api.common.exception.errorcode.AuthErrorCode;
@@ -60,5 +61,27 @@ public class AppleOauthClient {
             throw new BaseException(AuthErrorCode.APPLE_LOGIN_ERROR);
         }
         return responseBody;
+    }
+
+    public void revokeToken(RevokeTokenRequest revokeTokenRequest) throws BaseException{
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost("https://appleid.apple.com/auth/revoke");
+        List<NameValuePair> nvps = new ArrayList<>();
+        nvps.add(new BasicNameValuePair("client_id", revokeTokenRequest.getClient_id()));
+        nvps.add(new BasicNameValuePair("client_secret", revokeTokenRequest.getClient_secret()));
+        nvps.add(new BasicNameValuePair("token", revokeTokenRequest.getToken()));
+        nvps.add(new BasicNameValuePair("token_type_hint", revokeTokenRequest.getToken_type_hint()));
+        try {
+            httpPost.setEntity(new UrlEncodedFormEntity(nvps, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            log.error("Apple Revoke Token Request Body 인코딩 실패 : {}", revokeTokenRequest);
+            throw new BaseException(AuthErrorCode.APPLE_REVOKE_ERROR);
+        }
+        try {
+            httpClient.execute(httpPost);
+        } catch (IOException e) {
+            log.error("Apple Revoke Token 요청 실패 : {}", revokeTokenRequest);
+            throw new BaseException(AuthErrorCode.APPLE_REVOKE_ERROR);
+        }
     }
 }

--- a/src/main/java/com/modutaxi/api/common/auth/oauth/apple/dto/AppleAuthServerRequest.java
+++ b/src/main/java/com/modutaxi/api/common/auth/oauth/apple/dto/AppleAuthServerRequest.java
@@ -21,4 +21,17 @@ public class AppleAuthServerRequest {
         @JsonProperty("redirect_uri")
         private String redirect_uri;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RevokeTokenRequest {
+        @JsonProperty("client_id")
+        private String client_id;
+        @JsonProperty("client_secret")
+        private String client_secret;
+        @JsonProperty("token")
+        private String token;
+        @JsonProperty("token_type_hint")
+        private String token_type_hint;
+    }
 }

--- a/src/main/java/com/modutaxi/api/common/auth/oauth/apple/entity/AppleRefreshToken.java
+++ b/src/main/java/com/modutaxi/api/common/auth/oauth/apple/entity/AppleRefreshToken.java
@@ -1,0 +1,17 @@
+package com.modutaxi.api.common.auth.oauth.apple.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.io.Serializable;
+
+@Getter
+@AllArgsConstructor
+@Document(collection = "apple-refresh-token")
+public class AppleRefreshToken implements Serializable {
+    @Id
+    private String sub;
+    private String refresh_token;
+}

--- a/src/main/java/com/modutaxi/api/common/auth/oauth/apple/repository/AppleRefreshTokenMongoRepository.java
+++ b/src/main/java/com/modutaxi/api/common/auth/oauth/apple/repository/AppleRefreshTokenMongoRepository.java
@@ -1,0 +1,7 @@
+package com.modutaxi.api.common.auth.oauth.apple.repository;
+
+import com.modutaxi.api.common.auth.oauth.apple.entity.AppleRefreshToken;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface AppleRefreshTokenMongoRepository extends MongoRepository<AppleRefreshToken, String> {
+}

--- a/src/main/java/com/modutaxi/api/common/exception/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/modutaxi/api/common/exception/errorcode/AuthErrorCode.java
@@ -18,6 +18,7 @@ public enum AuthErrorCode implements ErrorCode {
     FAILED_SOCIAL_LOGIN("AUTH_007", "소셜 로그인에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     LOGOUT_JWT("AUTH_008", "로그아웃 처리된 JWT입니다.", HttpStatus.UNAUTHORIZED),
     APPLE_LOGIN_ERROR("AUTH_009", "Apple 로그인에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    APPLE_REVOKE_ERROR("AUTH_010", "Apple 탈퇴에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 
     private final String errorCode;

--- a/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
+++ b/src/main/java/com/modutaxi/api/domain/member/controller/UpdateMemberController.java
@@ -1,6 +1,7 @@
 package com.modutaxi.api.domain.member.controller;
 
 import com.modutaxi.api.common.auth.CurrentMember;
+import com.modutaxi.api.common.auth.oauth.apple.service.AppleService;
 import com.modutaxi.api.common.exception.errorcode.MailErrorCode;
 import com.modutaxi.api.common.exception.errorcode.SmsErrorCode;
 import com.modutaxi.api.domain.member.dto.MemberRequestDto.*;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class UpdateMemberController {
 
     private final UpdateMemberService updateMemberService;
+    private final AppleService appleService;
 
     /**
      * [PATCH] 로그인 토큰 갱신
@@ -374,6 +376,7 @@ public class UpdateMemberController {
     public ResponseEntity<Integer> deleteMember(
         @CurrentMember Member member) {
         updateMemberService.deleteMember(member);
+        appleService.revokeToken(member.getSnsId());
         return ResponseEntity.ok(200);
     }
 }

--- a/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
+++ b/src/main/java/com/modutaxi/api/domain/member/service/UpdateMemberService.java
@@ -110,7 +110,7 @@ public class UpdateMemberService {
     }
 
     public CertificationResponse checkSmsCertificationCodeWithJwt(Long memberId, String phoneNumber,
-                                                           String certificationCode) {
+                                                                  String certificationCode) {
         return new CertificationResponse(
             smsService.checkSmsCertificationCodeWithJwt(memberId.toString(), phoneNumber, certificationCode));
     }


### PR DESCRIPTION
## 요약 🎀
- 애플 리프레시 토큰 저장 로직 추가

## 상세 내용 🌈
- 애플 리프레시 토큰 저장로직을 추가하여 저희 애플리케이션의 회원가입 정보와 애플 인증서버 측의 회원가입 정보를 동기화하도록 구현하였습니다.
  - 회원가입
    <img width="500" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/cd30420c-cdf0-42df-8529-7b5063950dbe">
  - 로그인
    <img width="500" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/d67ee9d6-fd97-404a-8d17-7a4878a13566">
  - 애플리케이션 내 회원 탈퇴
    <img width="500" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/553f6f3a-2335-49c4-afdc-2dbae7ddd056">
  - 설정 앱을 통한 회원 탈퇴
    <img width="500" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/1005b0ae-a6c6-4f0f-a971-492f903774eb">

- 이러한 설정들로 다음과 같이 최초 회원가입과 로그인 시의 인증 화면과 정보 요구사항에서 사용자에게 차이점이 생기게 됩니다.
- 좌 : 회원가입, 우 : 로그인
<img height="460" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/09dcc78b-58ce-4209-9cef-2220a0c3a39d">

<img height="460" alt="image" src="https://github.com/MODU-TAXI/server-api/assets/58386334/c4f5248f-8cba-4166-b6d2-123919ec9716">

## 질문 및 이외 사항 🚩
- 애플 인증서버의 리프레시토큰은 다음과 같은 이유로 몽고데이터베이스에 저장하도록 구현하였습니다.
  - 회원가입, 로그인, 회원탈퇴시에만 쓰이는 정보
  - 다른 데이터와의 관계가 부족
  - 주요 서비스 로직과는 떨어진 데이터
- 현재 저희 스키마 구성으로는 사용자가 어떤 서비스를 이용하여 로그인을 하였는지 구분을 하지 않고 있습니다.
  따라서 카카오를 이용하여 회원가입한 사용자가 탈퇴를 하더라도 애플 회원 탈퇴 메서드로 들어갑니다.
  - 몽고데이터베이스에서 snsid를 찾는 과정에서 끝나기는 합니다.
  - 카카오의 snsid 형식과 애플의 sub 의 형식이 큰 차이가 존재하여 겹칠일은 없을것이라 보이긴한데 이에 대한 검증 단계가 필요하다고 생각하나요? ⁉️
- 애플 인증서버의 회원가입 정보는 dev 프로파일의 서버와 연결을 해둔상태이며, ios 애플리케이션의 번들 id 하나당 하나의 서버만이 연결되는 형태입니다.
  - 따라서 ios 측에서도 운영, qa, 개발용으로 번들을 나누는것이 적합하다고 생각이 되는데 어떻게 생각하나요?
  - 제가 알아본 결과로는 운영, 테스트, 개발 이런식으로 번들을 나누는 경우도 많이 있다고 알게되었습니다.

## 리뷰어에게 ✨
- 카카오는 이러한 설정 앱과 같은 외부 애플리케이션에서의 회원 탈퇴 접근에 대한 요구사항이 존재하지 않을까요? (단순 궁금증입니다.)
